### PR TITLE
Add link icons

### DIFF
--- a/src/sass/components/wiki.scss
+++ b/src/sass/components/wiki.scss
@@ -13,7 +13,7 @@
     background-position: 0% 60%;
     background-repeat: no-repeat;
     padding-left: 12px;
-    background-image: url(../default/external.png);
+    background-image: url(../../../images/external.png);
   }
 
   div.wiki *:not(pre)>code, div.wiki>code {


### PR DESCRIPTION
Story: https://insidemine.agileware.jp/redmine/issues/79580

アイコン画像の指定、存在しないディレクトリを指定していたので修正。
Redmineが標準で用意している画像を読みに行くように変更。