### PR TITLE
表の余白を拡大

### DIFF
--- a/src/sass/plugins/lychee.scss
+++ b/src/sass/plugins/lychee.scss
@@ -928,4 +928,26 @@
   .task-kanban-is-fullscreen #wrapper .global_banner {
     @apply ml-0
   }
+
+
+  // View Customize
+  .controller-view_customizes {
+    table.view_customize.box th {
+      @apply pl-3
+    }
+
+    table.view_customize.box td {
+      @apply pr-3
+    }
+
+    table.view_customize.box tr:first-child th,
+    table.view_customize.box tr:first-child td {
+      @apply pt-4
+    }
+
+    table.view_customize.box tr:last-child th,
+    table.view_customize.box tr:last-child td {
+      @apply pb-4
+    }
+  }
 }


### PR DESCRIPTION
Story: https://insidemine.agileware.jp/redmine/issues/80064

`table`と`.box`の組み合わせで作られており、新テーマでは`table`には`border-collapse: collapse;`を適用しているため、`.box`に設定している`padding`が消えていた。
`border-collapse: separate;`を復活させると、表が余白分横長になり、コンテンツエリアから見切れてスクロールが発生してしまうため最初の行と最後の行、thの左とtdの右という指定で余白を設定した。