### PR TITLE
Searchable Selectboxを導入している場合でも、チケット作成・編集画面ではフォームが小さくなるよう調整

### DIFF
--- a/src/sass/components/form.scss
+++ b/src/sass/components/form.scss
@@ -218,7 +218,7 @@
 
     // searchable selectboxを上書き
     .select2-container--default.select2-container--default .select2-selection--single {
-      @apply h-auto text-xs py-1.5 pl-2 pr-8
+      @apply h-[30px] text-xs py-1.5 pl-2 pr-8
     }
 
     .select2-container--default.select2-container--default .select2-selection--single .select2-selection__arrow {

--- a/src/sass/components/form.scss
+++ b/src/sass/components/form.scss
@@ -124,19 +124,6 @@
     @apply w-full
   }
 
-  // 個別系
-  // チケット作成・編集
-  .controller-issues {
-    .new_issue input:not([type="submit"]),
-    .new_issue select,
-    .new_issue textarea,
-    .edit_issue input:not([type="submit"]),
-    .edit_issue select,
-    .edit_issue textarea {
-      @apply text-xs py-1.5 pl-2
-    }
-  }
-
   // ファイル添付・コメント投稿系
   input[type="file"] {
     @apply block w-full bg-background-secondary text-sm text-text-default p-2 rounded-md
@@ -192,10 +179,6 @@
 
   // 詳細度を高めて上書きが必要
   .select2-container--default.select2-container--default .select2-selection--single {
-    // background-image: url(images/expand_more_dark.svg);
-    // background-repeat: no-repeat;
-    // background-position: right 8px center;
-
     @extend .TEXT_FIELD;
     @apply h-[38px] pr-8
   }
@@ -213,12 +196,37 @@
   }
 
   .select2-container--default.select2-container--default .select2-selection--single .select2-selection__rendered {
-    // line-height: normal;
     padding-left: 0 !important;
     @apply text-sm text-text-default px-0 pt-0
   }
 
   .select2-container--default.select2-container--default.select2-container--focus .select2-selection--multiple {
     @apply border-text-default
+  }
+
+  // 個別系
+  // チケット作成・編集のみフォームサイズを小さくする
+  .controller-issues {
+    .new_issue input:not([type="submit"]),
+    .new_issue select,
+    .new_issue textarea,
+    .edit_issue input:not([type="submit"]),
+    .edit_issue select,
+    .edit_issue textarea {
+      @apply text-xs py-1.5 pl-2
+    }
+
+    // searchable selectboxを上書き
+    .select2-container--default.select2-container--default .select2-selection--single {
+      @apply h-auto text-xs py-1.5 pl-2 pr-8
+    }
+
+    .select2-container--default.select2-container--default .select2-selection--single .select2-selection__arrow {
+      @apply h-[16px]
+    }
+
+    .select2-container--default.select2-container--default .select2-selection--single .select2-selection__rendered {
+      @apply text-xs
+    }
   }
 }


### PR DESCRIPTION
このテーマでは、入力しやすさを優先してフォームのサイズを大きくした。
しかし、それにより一覧性が低下するということが起こったため、フォームを小さくすることにした。
最初のステップとして、一覧性が高いほうが嬉しいであろうチケット作成・編集画面のinput、textareaを小さくしたが、Redmine searchable selectbox pluginの対応が漏れていたため、修正した。