### PR TITLE
不要な色指定削除

### DIFF
--- a/src/sass/components/topMenu.scss
+++ b/src/sass/components/topMenu.scss
@@ -169,6 +169,6 @@
 
   // Lychee Billing
   #top-menu #lychee-billng-global-message#lychee-billng-global-message {
-    @apply order-1 text-inherit
+    @apply order-1
   }
 }


### PR DESCRIPTION
Billing対応で文字色の変更を行ったが、別対応でtopMenuの背景色を変更したため不要となった。