### PR TITLE
高さを変更

### DIFF
--- a/src/sass/components/mainMenu.scss
+++ b/src/sass/components/mainMenu.scss
@@ -1,6 +1,7 @@
 @layer components {
   #main-menu {
-    @apply overflow-auto absolute left-0 w-52 h-full bg-primitive-darkGray-600 pt-3 px-2 pb-20
+    height: calc(100vh - 44px);
+    @apply overflow-auto absolute left-0 w-52 bg-primitive-darkGray-600 pt-3 px-2 pb-20
   }
 
   #main-menu.aw_fixed_header {


### PR DESCRIPTION
height: 100%;の場合にガタつきが発生していたため、topMenu分の高さをマイナスした値をセットした