### PR TITLE
2カラムに戻したうえで、見切れていた部分などを調整

### DIFF
--- a/src/sass/pages/issues.scss
+++ b/src/sass/pages/issues.scss
@@ -156,54 +156,12 @@
       @apply my-4
     }
 
-    // editフォームのレイアウト変更
-    #issue-form #all_attributes .splitcontent {
-      @apply flex-col
-    }
-
     #issue-form #all_attributes .splitcontentleft {
-      @apply mr-0
+      @apply mr-0 mb-2
     }
 
     #issue-form #all_attributes .splitcontentright {
-      @apply mt-4 ml-0
-    }
-
-    #issue-form #all_attributes .splitcontent:first-child .splitcontentright {
-      @apply flex flex-wrap
-    }
-
-    #issue-form #parent_issue {
-      @apply w-full
-    }
-
-    #actual_dates_area {
-      @apply flex w-full
-    }
-
-    #actual_due_date_area {
-      @apply mt-0
-    }
-
-    #due_date_area,
-    #actual_due_date_area,
-    #remaining_estimate_area,
-    #remaining_estimate_area + p {
-      @apply pl-[5.5rem]
-    }
-
-    #due_date_area label,
-    #actual_due_date_area label,
-    #remaining_estimate_area label,
-    #remaining_estimate_area + p label {
-      @apply w-[4.5rem] -ml-[5.5rem]
-    }
-
-
-    #due_date_area,
-    #actual_due_date_area {
-      background-image: url(images/double_arrow_right_dark.svg);
-      @apply bg-no-repeat bg-[left_center]
+      @apply ml-0
     }
 
     #log_time .splitcontent {

--- a/src/sass/plugins/lychee.scss
+++ b/src/sass/plugins/lychee.scss
@@ -36,7 +36,7 @@
 
   // Lychee Actual Date
   #actual_dates_area {
-    @apply mt-4
+    @apply mt-2
   }
 
 

--- a/src/sass/responsives/responsive.scss
+++ b/src/sass/responsives/responsive.scss
@@ -960,33 +960,6 @@
     @apply flex-wrap
   }
 
-  .controller-issues {
-    #due_date_area,
-    #actual_due_date_area,
-    #remaining_estimate_area,
-    #remaining_estimate_area + p {
-      @apply pl-0
-    }
-
-    #due_date_area label,
-    #actual_due_date_area label,
-    #remaining_estimate_area label,
-    #remaining_estimate_area + p label {
-      @apply w-full ml-0
-    }
-
-    #start_date_area,
-    #actual_start_date_area {
-      @apply w-[9rem]
-    }
-
-    #due_date_area,
-    #actual_due_date_area {
-      width: calc(100% - 9rem);
-      @apply pl-6 bg-[left_bottom_14px]
-    }
-  }
-
   /* attachment upload form */
   .attachments_fields span {
     position: relative;


### PR DESCRIPTION
チケット新規作成・編集の `.splitcontent` を2カラムに戻した。
それによって横幅が狭くなり、開始日期日等の日付が見切れるようになったため、開始日期日を横並びにしてつながりを表現していた箇所を標準スタイルに戻した。