### PR TITLE
余白を調整

### DIFF
--- a/src/sass/plugins/lychee.scss
+++ b/src/sass/plugins/lychee.scss
@@ -137,6 +137,10 @@
     main button {
       @apply px-1
     }
+
+    #content {
+      @apply p-4
+    }
   }
 
 


### PR DESCRIPTION
カレンダー方式のタイムマネジメントのみ、左側に不自然な余白が生じていたので調整した。
