### PR TITLE
英語表示時の改行が見づらかったため変更

### DIFF
--- a/src/sass/components/mainMenu.scss
+++ b/src/sass/components/mainMenu.scss
@@ -29,7 +29,7 @@
   }
 
   #main-menu li a {
-    @apply block whitespace-normal break-all text-text-default text-xs no-underline px-3 py-2.5 rounded
+    @apply block whitespace-normal break-words text-text-default text-xs no-underline px-3 py-2.5 rounded
   }
 
   #main-menu > ul > li > a {


### PR DESCRIPTION
ユーザーの言語設定を英語にした状態でメインメニューを縮小すると、改行がされず見切れてしまう問題が発生していた。
その対処として、`break-all`を設定したが、レビューにて改行位置が不自然とフィードバックがあった。

例えば
`Spent Time`であれば
```
Spent Ti
me
```
のように、横幅に合わせて改行されており、各単語が分かりづらくなっていた。
その対応として、`break-word`を設定した。