### PR TITLE
LIFが開いているときのコンテンツエリアがLIFウィンドウに合わせて縮小しないようにする

### DIFF
--- a/src/sass/base/base.scss
+++ b/src/sass/base/base.scss
@@ -1,4 +1,4 @@
-table, tbody, thead, tr, th, td {
+body, table, tbody, thead, tr, th, td {
   box-sizing: content-box;
 }
 

--- a/src/sass/components/mainMenu.scss
+++ b/src/sass/components/mainMenu.scss
@@ -1,7 +1,7 @@
 @layer components {
   #main-menu {
     height: calc(100vh - 1px);
-    @apply overflow-auto absolute left-0 w-52 bg-primitive-darkGray-600 pt-3 px-2 pb-20
+    @apply overflow-auto absolute left-0 w-52 bg-primitive-darkGray-600 pt-3 px-2 pb-20 z-[400]
   }
 
   #main-menu.aw_fixed_header {


### PR DESCRIPTION
Lycheeテーマベーシック適用時にLycheeIssueFormを開くと、開いたウィンドウに合わせてコンテンツ側が縮小しており見づらくなる。
Redmineデフォルトテーマに合わせて、縮小しないように変更した。

bodyの設定を変更。
それによって横スクロール時に左に配置したmain-menuに一部のコンテンツが重なってしまう現象を確認したので、にz-indexの調整が必要になったのでそちらも対応。