### PR TITLE
main-menuの縮小と開閉機能の削除

### DIFF
--- a/src/js/index.js
+++ b/src/js/index.js
@@ -49,53 +49,6 @@ function stickyMainMenu() {
   }
 }
 
-function addBtnToToggleMainMenu() {
-  const mainMenu = document.querySelector('#main-menu')
-  const btn = document.createElement('button')
-  btn.textContent = 'メニューの開閉'
-  btn.classList.add('aw_toggleMainMenu')
-
-  mainMenu.appendChild(btn)
-}
-
-function openMainMenu() {
-  document.querySelector('#main-menu').classList.remove('isMainMenuClose')
-  document.querySelector('#main').classList.remove('isMainMenuClose')
-  document.querySelector('.aw_toggleMainMenu').classList.remove('isMainMenuClose')
-  document.querySelector('#wrapper').classList.remove('isMainMenuClose')
-  document.querySelector('#header').classList.remove('isMainMenuClose')
-}
-
-function closeMainMenu() {
-  document.querySelector('#main-menu').classList.add('isMainMenuClose')
-  document.querySelector('#main').classList.add('isMainMenuClose')
-  document.querySelector('.aw_toggleMainMenu').classList.add('isMainMenuClose')
-  document.querySelector('#wrapper').classList.add('isMainMenuClose')
-  document.querySelector('#header').classList.add('isMainMenuClose')
-}
-
-function toggleMainMenu() {
-  const mainMenu = document.querySelector('#main-menu')
-
-  if(mainMenu.classList.contains('isMainMenuClose')) {
-    openMainMenu()
-  } else {
-    closeMainMenu()
-  }
-}
-
-function initToggleMainMenu() {
-  const mainMenu = document.querySelector('#main-menu')
-  if(!mainMenu) return
-
-  // toggle btnの追加
-  addBtnToToggleMainMenu()
-
-  // 開閉処理
-  const toggleTrigger = document.querySelector('.aw_toggleMainMenu')
-  toggleTrigger.addEventListener('click', toggleMainMenu)
-}
-
 // Sidebarの折りたたみ
 function addBtnToToggleSidebar() {
   const sidebar = document.querySelector('#sidebar')
@@ -179,9 +132,8 @@ window.addEventListener('DOMContentLoaded', () => {
   addFeedbackLink()
 
   /**
-   * Main Menu / Sidebarの開閉機能
+   * Sidebarの開閉機能
    */
-  initToggleMainMenu()
   initToggleSidebar()
 
   // mainMenuがあるかどうか

--- a/src/sass/components/buttons.scss
+++ b/src/sass/components/buttons.scss
@@ -51,29 +51,6 @@
     @extend .BTN_SECONDARY;
   }
 
-  // Main Menuの開閉ボタン
-  .aw_toggleMainMenu {
-    @extend .BTN_TERTIARY_ICON_ONLY_OUTLINED;
-    background-image: url(images/move_left_default.svg);
-    @apply absolute top-[1rem] left-[0.75rem] z-10
-  }
-
-  .aw_toggleMainMenu.isMainMenuClose {
-    background-image: url(images/move_right_default.svg);
-  }
-
-  .lgc-is-fullscreen .aw_toggleMainMenu,
-  .task-kanban-is-fullscreen .aw_toggleMainMenu,
-  .controller-resource_management .aw_toggleMainMenu,
-  .controller-lychee_message_box_my_boxes .aw_toggleMainMenu,
-  .controller-lychee_message_box_informations .aw_toggleMainMenu,
-  .controller-lychee_message_box_system_errors .aw_toggleMainMenu,
-  .controller-time_management .aw_toggleMainMenu,
-  .controller-project_report_overview .aw_toggleMainMenu,
-  .controller-lychee_work_plan .aw_toggleMainMenu {
-    @apply hidden
-  }
-
   // Sidebarの開閉ボタン
   .aw_toggleSidebar {
     @extend .BTN_TERTIARY_ICON_ONLY_OUTLINED;
@@ -214,7 +191,7 @@
 
     background-image: url(images/add_dark.svg);
 
-    @apply bg-no-repeat bg-[length:16px_16px] bg-center
+    @apply mb-2 mx-[18px]
   }
 
   #main-menu li a.new-object:hover,

--- a/src/sass/components/header.scss
+++ b/src/sass/components/header.scss
@@ -4,12 +4,7 @@
   }
 
   #header.aw_hasMainMenu {
-    @apply pl-56
-  }
-
-  #header.isMainMenuClose,
-  #header.aw_hasMainMenu.isMainMenuClose {
-    @apply pl-[5rem]
+    @apply pl-[5.5rem]
   }
 
   #header h1 {

--- a/src/sass/components/mainMenu.scss
+++ b/src/sass/components/mainMenu.scss
@@ -1,18 +1,14 @@
 @layer components {
   #main-menu {
     height: calc(100vh - 1px);
-    @apply overflow-auto absolute left-0 w-52 bg-primitive-darkGray-600 pt-3 px-2 pb-20 z-[400]
+    @apply overflow-scroll absolute left-0 w-[4.5rem] bg-primitive-darkGray-600 pt-3 px-1 pb-20 z-[400]
   }
 
   #main-menu.aw_fixed_header {
     @apply fixed
   }
 
-  #main-menu.isMainMenuClose {
-    @apply w-[4rem] px-1
-  }
-
-  #main-menu.isMainMenuClose::-webkit-scrollbar {
+  #main-menu::-webkit-scrollbar {
     @apply hidden
   }
 
@@ -20,11 +16,11 @@
     @apply flex flex-col w-full whitespace-nowrap m-0 p-0
   }
 
-  #main-menu ul:not(.menu-children) {
-    @apply mt-9
+  #main-menu li {
+    @apply relative
   }
 
-  #main-menu.isMainMenuClose li:not(:first-child) {
+  #main-menu li:not(:first-child) {
     @apply mt-1
   }
 
@@ -33,24 +29,20 @@
   }
 
   #main-menu > ul > li > a {
-    @apply cursor-pointer text-text-onFill
+    @apply cursor-pointer relative text-text-onFill text-[11px] leading-[1.4] py-2 px-1.5
   }
 
   #main-menu .lychee-icon.lychee-icon:before, #main-menu .lychee-icon.lychee-icon.selected:before {
     content: url(images/lychee_onFill.svg);
   }
 
-  #main-menu.isMainMenuClose > ul > li > a {
-    @apply relative text-[11px] leading-[1.4] py-2.5 px-1
-  }
-
   // メインメニューを閉じているときはlycheeアイコンを調整する
-  #main-menu.isMainMenuClose > ul > li > a.lychee-icon {
+  #main-menu > ul > li > a.lychee-icon {
     @apply relative pl-2
   }
 
-  #main-menu.isMainMenuClose .lychee-icon.lychee-icon:before,
-  #main-menu.isMainMenuClose .lychee-icon.lychee-icon.selected:before {
+  #main-menu .lychee-icon.lychee-icon:before,
+  #main-menu .lychee-icon.lychee-icon.selected:before {
     content: '';
     background-image: url(images/lychee_onFill.svg);
     @apply absolute top-0.5 left-0.5 inline-block w-2 h-2 bg-no-repeat bg-contain
@@ -64,19 +56,6 @@
     @apply bg-primitive-darkGray-700
   }
 
-  .aw_newObjectList {
-    @apply absolute top-[1rem] right-[0.75rem] w-6
-  }
-
-  .isMainMenuClose .aw_newObjectList {
-    @apply hidden
-  }
-
-  #main-menu li:hover ul.menu-children,
-  #main-menu li ul.menu-children.visible {
-    @apply right-0 block w-[11rem]
-  }
-
   #main-menu li a.selected,
   #main-menu li a.selected:hover {
     @apply bg-primitive-darkGray-900
@@ -88,6 +67,11 @@
 
   // main-menu > new-object
   #main-menu .menu-children {
-    @apply hidden absolute w-auto bg-background-primary border border-border-default p-1 rounded-md shadow-lg z-[45]
+    @apply hidden fixed w-auto bg-background-primary border border-border-default p-1 rounded-md shadow-lg z-[1]
+  }
+
+  #main-menu li:hover ul.menu-children,
+  #main-menu li ul.menu-children.visible {
+    @apply left-2 block w-[11rem]
   }
 }

--- a/src/sass/layout/layout.scss
+++ b/src/sass/layout/layout.scss
@@ -9,7 +9,7 @@
   }
 
   .has-main-menu #main {
-    @apply ml-52
+    @apply ml-[4.5rem]
   }
 
   #main.nosidebar {
@@ -17,25 +17,7 @@
   }
 
   .has-main-menu #main.nosidebar {
-    @apply ml-52
-  }
-
-  // 開閉時の設定
-  #main.isMainMenuClose,
-  .has-main-menu #main.nosidebar.isMainMenuClose {
-    @apply ml-[4rem]
-  }
-
-  .controller-resource_management #main.nosidebar.isMainMenuClose,
-  .controller-project_report_overview #main.nosidebar.isMainMenuClose,
-  .controller-lychee_work_plan #main.nosidebar.isMainMenuClose,
-  .controller-time_management #main.nosidebar.isMainMenuClose,
-  .controller-lychee_message_box_informations #main.nosidebar.isMainMenuClose,
-  .controller-lychee_message_box_my_boxes #main.nosidebar.isMainMenuClose,
-  .controller-lychee_message_box_system_errors #main.nosidebar.isMainMenuClose,
-  .controller-lychee_billing #main.nosidebar.isMainMenuClose
-  {
-    @apply ml-0
+    @apply ml-[4.5rem]
   }
 
   #content {

--- a/src/sass/plugins/lychee.scss
+++ b/src/sass/plugins/lychee.scss
@@ -622,7 +622,7 @@
     }
 
     #header.aw_hasMainMenu {
-      @apply pl-4
+      @apply pl-[5.5rem]
     }
   }
 

--- a/src/sass/plugins/oss.scss
+++ b/src/sass/plugins/oss.scss
@@ -4,72 +4,57 @@
   // NOTE: メインメニューのサイドバー化の影響で、bannerがメインメニューと重なってしまう
   //       メインメニューのあり／なしでスタイルを変える
   //       プロレポや全画面表示など、見かけ上ではメインメニューが存在しないが、非表示になっているだけのページが存在するので注意
-  .has-main-menu #wrapper .global_banner {
-    @apply ml-52
-  }
-
-  // メインメニューを閉じたときの対応
-  #wrapper.isMainMenuClose .global_banner {
-    @apply ml-[4rem]
+  .has-main-menu .global_banner {
+    @apply ml-[4.5rem]
   }
 
   // メインメニューを非表示にしているLycheeプラグインの画面対応
-  .controller-resource_management #wrapper .global_banner,
-  .controller-project_report_overview #wrapper .global_banner,
-  .controller-lychee_work_plan #wrapper .global_banner,
-  .controller-time_management #wrapper .global_banner,
-  .controller-lychee_message_box_informations #wrapper .global_banner,
-  .controller-lychee_message_box_my_boxes #wrapper .global_banner,
-  .controller-lychee_message_box_system_errors #wrapper .global_banner,
-  .lgc-is-fullscreen #wrapper .global_banner,
-  .task-kanban-is-fullscreen #wrapper .global_banner {
+  .controller-resource_management .global_banner,
+  .controller-project_report_overview .global_banner,
+  .controller-lychee_work_plan .global_banner,
+  .controller-time_management .global_banner,
+  .controller-lychee_message_box_informations .global_banner,
+  .controller-lychee_message_box_my_boxes .global_banner,
+  .controller-lychee_message_box_system_errors .global_banner,
+  .lgc-is-fullscreen .global_banner,
+  .task-kanban-is-fullscreen .global_banner {
     @apply ml-0
   }
 
   @media screen and (max-width: 1250px) {
-    .has-main-menu #wrapper .global_banner {
-      @apply ml-44
-    }
-
-    // メインメニューを閉じたときの対応
-    #wrapper.isMainMenuClose .global_banner {
-      @apply ml-20
+    .has-main-menu .global_banner {
+      @apply ml-[4.5rem]
     }
 
     // メインメニューを非表示にしているLycheeプラグインの画面対応
-    .controller-resource_management #wrapper .global_banner,
-    .controller-project_report_overview #wrapper .global_banner,
-    .controller-lychee_work_plan #wrapper .global_banner,
-    .controller-time_management #wrapper .global_banner,
-    .controller-lychee_message_box_informations #wrapper .global_banner,
-    .controller-lychee_message_box_my_boxes #wrapper .global_banner,
-    .controller-lychee_message_box_system_errors #wrapper .global_banner,
-    .lgc-is-fullscreen #wrapper .global_banner,
-    .task-kanban-is-fullscreen #wrapper .global_banner {
+    .controller-resource_management .global_banner,
+    .controller-project_report_overview .global_banner,
+    .controller-lychee_work_plan .global_banner,
+    .controller-time_management .global_banner,
+    .controller-lychee_message_box_informations .global_banner,
+    .controller-lychee_message_box_my_boxes .global_banner,
+    .controller-lychee_message_box_system_errors .global_banner,
+    .lgc-is-fullscreen .global_banner,
+    .task-kanban-is-fullscreen .global_banner {
       @apply ml-0
     }
   }
 
   @media screen and (max-width: 899px) {
-    .has-main-menu #wrapper .global_banner {
-      @apply ml-0
-    }
-
-    // メインメニューを閉じたときの対応
-    #wrapper.isMainMenuClose .global_banner {
+    .has-main-menu .global_banner {
       @apply ml-0
     }
 
     // メインメニューを非表示にしているLycheeプラグインの画面対応
-    .controller-resource_management #wrapper .global_banner,
-    .controller-project_report_overview #wrapper .global_banner,
-    .controller-lychee_work_plan #wrapper .global_banner,
-    .controller-time_management #wrapper .global_banner,
-    .controller-lychee_message_box_informations #wrapper .global_banner,
-    .controller-lychee_message_box_my_boxes #wrapper .global_banner,
-    .controller-lychee_message_box_system_errors #wrapper .global_banner,
-    .lgc-is-fullscreen #wrapper .global_banner,
-    .task-kanban-is-fullscreen #wrapper .global_banner {
+    .controller-resource_management .global_banner,
+    .controller-project_report_overview .global_banner,
+    .controller-lychee_work_plan .global_banner,
+    .controller-time_management .global_banner,
+    .controller-lychee_message_box_informations .global_banner,
+    .controller-lychee_message_box_my_boxes .global_banner,
+    .controller-lychee_message_box_system_errors .global_banner,
+    .lgc-is-fullscreen .global_banner,
+    .task-kanban-is-fullscreen .global_banner {
       @apply ml-0
     }
   }

--- a/src/sass/responsives/responsive.scss
+++ b/src/sass/responsives/responsive.scss
@@ -27,55 +27,6 @@
 */
 
 @media screen and (max-width: 1250px) {
-  #top-menu {
-    @apply text-xs
-  }
-
-  #header.aw_hasMainMenu {
-    @apply pl-48
-  }
-
-  .has-main-menu #main {
-    @apply ml-44
-  }
-
-  #main.nosidebar {
-    @apply ml-0
-  }
-
-  .has-main-menu #main.nosidebar {
-    @apply ml-44
-  }
-
-  #main.isMainMenuClose,
-  .has-main-menu #main.nosidebar.isMainMenuClose {
-    @apply ml-[5rem]
-  }
-
-  .controller-resource_management,
-  .controller-project_report_overview,
-  .controller-lychee_work_plan,
-  .controller-time_management,
-  .controller-lychee_message_box_informations.controller-lychee_message_box_informations,
-  .controller-lychee_message_box_my_boxes.controller-lychee_message_box_my_boxes,
-  .controller-lychee_message_box_system_errors.controller-lychee_message_box_system_errors {
-    #main.nosidebar {
-      @apply ml-0
-    }
-  }
-
-  #main-menu {
-    @apply w-44
-  }
-
-  #main-menu li:not(:first-child) {
-    @apply mt-1
-  }
-
-  #main-menu li a {
-    @apply text-xs
-  }
-
   #sidebar {
     @apply w-48
   }


### PR DESCRIPTION
- 開閉状態を記憶したい
  - コンテンツエリアを大きく表示するため、メインメニューは常に閉じておきたい人が多い
- しかし開閉状態を記憶すると、閉じた状態で画面遷移すると画面がちらつく
  - 読み込みが遅いページだと、HTMLの描画からテーマjsの実行までにラグが発生するため、`メニューが一瞬開いた後閉じる`のような挙動が発生して見づらい

上記のような経緯があり、
メインメニューを閉じておきたい人が多いのであれば、最初からメインメニューは小さい状態にしておき、開閉機能自体もなくしてしまえばチラつくこともないということで、メニューの幅を小さくし、開閉機能を削除することになった。