### PR TITLE
チケット閲覧画面における各項目の表示方法を標準cssを利用するように変更

### DIFF
--- a/src/sass/pages/issues.scss
+++ b/src/sass/pages/issues.scss
@@ -37,15 +37,15 @@
     }
 
     div.issue .attributes .attribute {
-      @apply flex items-center mb-1 pl-0
+      @apply mb-1
     }
 
     div.issue .attributes .attribute .label {
-      @apply float-none block w-auto text-sm text-text-default text-left my-0 mr-2 ml-0
+      @apply text-sm text-text-default
     }
 
     div.issue .attribute .value {
-      @apply max-w-none text-sm text-text-default
+      @apply text-sm text-text-default
     }
 
     div.issue .attribute .value a {


### PR DESCRIPTION
カスタムフィールドに長めの文字列を入れると、カスタムフィールドのラベルが消えてしまう

### 経緯など
チケット閲覧画面における各項目の表示方法を `float` から `flex` に変更していた。
その際に `flex-shrink` を指定し忘れていたことで、項目に長いテキストが入った場合にラベルが見切れるという不具合が発生していた。

<img width="456" alt="cf-label" src="https://github.com/agileware-jp/lychee_theme_basic/assets/117145503/51d6d06a-978f-4df8-9727-f86ff6a3b4ba">

`display: flex;`に変更する理由が特になかったため、`flex-shrink`を指定するのではなく元に戻す形に変更した