### PR TITLE
添付中ファイルの表示UIのクリップアイコンとファイル名の余白調整

### DIFF
--- a/src/sass/components/form.scss
+++ b/src/sass/components/form.scss
@@ -133,6 +133,10 @@
     @apply mt-0
   }
 
+  .attachments_fields input.icon-attachment {
+    @apply pl-4
+  }
+
   .attachments_fields .description {
     @apply mb-2
   }
@@ -214,6 +218,10 @@
     .edit_issue select,
     .edit_issue textarea {
       @apply text-xs py-1.5 pl-2
+    }
+
+    .attachments_fields input.icon-attachment {
+      @apply pl-4
     }
 
     // searchable selectboxを上書き


### PR DESCRIPTION
添付ファイルをセットしたときに表示されるクリップアイコンとファイル名の間が狭くて見づらい

<img width="228" alt="file_attachments_ui" src="https://github.com/agileware-jp/lychee_theme_basic/assets/117145503/eea912ab-0dc0-4658-adfe-4b842d410c41">

ファイル添付後に表示される「クリップアイコン」と「添付ファイル名」間の余白がなくなっていたので調整した