### PR TITLE
意図的に小さくしていたフォームやボタンのサイズを、デフォルトサイズに戻す

### DIFF
--- a/src/sass/components/buttons.scss
+++ b/src/sass/components/buttons.scss
@@ -338,7 +338,7 @@
     .reflect_critical_path {
       background-image: url(images/refresh_default.svg);
       @extend .BTN_SECONDARY_ICON_LEFT;
-      @apply mt-2
+      @apply bg-[0.5rem_center]
     }
   }
 

--- a/src/sass/components/buttons.scss
+++ b/src/sass/components/buttons.scss
@@ -232,26 +232,21 @@
   // 設定 > ユーザー
   .controller-admin,
   .controller-groups {
-    h2 + form input[type="submit"] {
-      @extend .BTN_PRIMARY;
-      @apply text-xs py-1 px-2 ml-1
-    }
-
     input[type="submit"] + .icon-reload {
       @extend .BTN_SECONDARY_ICON_LEFT;
-      @apply bg-[0.5rem_center] bg-[length:14px_14px] text-xs py-1 pr-2 pl-6 ml-1
+      @apply bg-[0.5rem_center] bg-[length:14px_14px] text-xs py-1.5 pr-2 pl-6 ml-1
     }
   }
 
   .controller-users.action-index {
     h2 + form input[type="submit"] {
       @extend .BTN_PRIMARY;
-      @apply text-xs py-1 px-2 ml-1
+      @apply text-xs py-1.5 px-2 ml-1
     }
 
     input[type="submit"] + .icon-reload {
       @extend .BTN_SECONDARY_ICON_LEFT;
-      @apply bg-[0.5rem_center] bg-[length:14px_14px] text-xs py-1 pr-2 pl-6 ml-1
+      @apply bg-[0.5rem_center] bg-[length:14px_14px] text-xs py-1.5 pr-2 pl-6 ml-1
     }
   }
 
@@ -259,12 +254,12 @@
     #tab-content-versions {
       form input[type="submit"] {
         @extend .BTN_PRIMARY;
-        @apply text-xs py-1 px-2 ml-1
+        @apply text-xs py-1.5 px-2 ml-1
       }
   
       input[type="submit"] + .icon-reload {
         @extend .BTN_SECONDARY_ICON_LEFT;
-        @apply bg-[0.5rem_center] bg-[length:14px_14px] text-xs py-1 pr-2 pl-6 ml-1
+        @apply bg-[0.5rem_center] bg-[length:14px_14px] text-xs py-1.5 pr-2 pl-6 ml-1
       }
     }
 
@@ -279,12 +274,12 @@
 
   .controller-roles {
     #filters form input[type="submit"] {
-      @apply text-xs py-1 px-2
+      @apply text-xs py-1.5 px-2
     }
 
     #filters form .icon-reload {
       @extend .BTN_SECONDARY_ICON_LEFT;
-      @apply bg-[0.5rem_center] bg-[length:14px_14px] text-xs py-1 pr-2 pl-6 ml-1
+      @apply bg-[0.5rem_center] bg-[length:14px_14px] text-xs py-1.5 pr-2 pl-6 ml-1
     }
   }
 
@@ -306,7 +301,7 @@
   .controller-time_management {
     #filters + .buttons .icon-checked {
       @extend .BTN_LINK;
-      @apply bg-[left_center] text-xs pr-2 pl-4 py-1 shadow-none
+      @apply bg-[left_center] text-xs pr-2 pl-4 py-1.5 shadow-none
     }
   }
 
@@ -317,7 +312,7 @@
 
   #lychee_cost_expenses #x_months ~ a {
     @extend .BTN_SECONDARY_ICON_LEFT;
-    @apply bg-[0.5rem_center] bg-[length:14px_14px] text-xs py-1 pr-2 pl-6 ml-1
+    @apply bg-[0.5rem_center] bg-[length:14px_14px] text-xs py-1.5 pr-2 pl-6 ml-1
   }
 
   .lychee_cost_expenses .icon.icon-edit,

--- a/src/sass/components/filter.scss
+++ b/src/sass/components/filter.scss
@@ -647,7 +647,7 @@
   // 管理→設定→グループ(buttons.scssも参照)
   .controller-groups {
     h2 + form {
-      @apply clear-both text-xs
+      @apply clear-both
     }
 
     h2 + form fieldset {
@@ -657,41 +657,21 @@
     h2 + form fieldset legend {
       @apply text-text-caption text-xs font-bold
     }
-
-    h2 + form fieldset {
-      select {
-        @apply text-xs py-1 pr-6 pl-2 my-0
-      }
-
-      input:not([type="submit"]) {
-        @apply text-xs py-1 px-2 my-0
-      }
-    }
   }
 
   // プロジェクト設定→バージョンのフィルタ
   .controller-projects {
     #tab-content-versions {
       form {
-        @apply clear-both text-xs
+        @apply clear-both
       }
 
       form fieldset {
         @apply pt-2 px-3 pb-3 rounded-md
       }
-  
+
       form fieldset legend {
         @apply text-text-caption text-xs font-bold
-      }
-  
-      form fieldset {
-        select {
-          @apply text-xs py-1 pr-6 pl-2 my-0
-        }
-  
-        input:not([type="submit"]) {
-          @apply text-xs py-1 px-2 my-0
-        }
       }
     }
   }

--- a/src/sass/components/filter.scss
+++ b/src/sass/components/filter.scss
@@ -1,20 +1,4 @@
 @layer components {
-  #query_form,
-  body:not(.controller-queries) #query-form,
-  #levm_query_form {
-    select {
-      @apply text-xs py-1 pr-6 pl-2 my-0
-    }
-
-    select[multiple] {
-      @apply px-1
-    }
-
-    input:not([type="checkbox"], [type="radio"], [type="submit"]) {
-      @apply text-xs py-1 px-2 my-0
-    }
-  }
-
   #filters-table {
     @apply w-full
   }
@@ -623,7 +607,7 @@
   // 管理→設定→フィルタ(buttons.scssも参照)
   .controller-admin {
     h2 + form {
-      @apply clear-both text-xs
+      @apply clear-both
     }
 
     h2 + form fieldset {
@@ -634,16 +618,6 @@
       @apply text-text-caption text-xs font-bold
     }
 
-    h2 + form fieldset {
-      select {
-        @apply text-xs py-1 pr-6 pl-2 my-0
-      }
-
-      input:not([type="submit"]) {
-        @apply text-xs py-1 px-2 my-0
-      }
-    }
-
     fieldset #status {
       @apply mr-2
     }
@@ -652,7 +626,7 @@
   // 管理→設定→ユーザー(buttons.scssも参照)
   .controller-users {
     #users_form {
-      @apply clear-both text-xs
+      @apply clear-both
     }
 
     #users_form fieldset {
@@ -661,16 +635,6 @@
 
     #users_form fieldset legend {
       @apply text-text-caption text-xs font-bold
-    }
-
-    #users_form fieldset {
-      select {
-        @apply text-xs py-1 pr-6 pl-2 my-0
-      }
-
-      input:not([type="subtmi"]) {
-        @apply text-xs py-1 px-2 my-0
-      }
     }
 
     fieldset #status,

--- a/src/sass/components/form.scss
+++ b/src/sass/components/form.scss
@@ -30,6 +30,10 @@
     @extend .TEXT_FIELD;
   }
 
+  input[type="date"] {
+    @apply h-[30px]
+  }
+
   textarea {
     @extend .TEXT_FIELD;
   }


### PR DESCRIPTION
入力フィールドやボタンサイズが大きかった頃に、フィルタ周りの入力フィールドやボタンのみ小さくするために余白を小さくしていた。
入力フィールドとボタン全般の大きさを調整した際に、↑で変更していた箇所の対応が漏れていたので、それに関連する箇所のサイズをあわせた。