### PR TITLE
Fix 82904 旧Lycheeガントチャートのカスタムクエリ保存画面の余白が全体的に不自然

### DIFF
--- a/src/js/index.js
+++ b/src/js/index.js
@@ -202,4 +202,13 @@ window.addEventListener('DOMContentLoaded', () => {
   if(newObjectBtn) {
     newObjectBtn.closest('li').classList.add('aw_newObjectList')
   }
+
+
+  /**
+   * LGCのカスタムクエリ作成ページかどうかを判定
+   */
+  const lgcQueriesBodyClasses = document.body.classList
+  if([...lgcQueriesBodyClasses].includes('controller-lgc/queries')) {
+    document.body.classList.add('aw_lgcQueries')
+  }
 })

--- a/src/sass/components/filter.scss
+++ b/src/sass/components/filter.scss
@@ -169,6 +169,21 @@
     }
   }
 
+  .aw_lgcQueries {
+  // Note:lgcのカスタムクエリ作成画面は、bodyに`controller-lgc/queries`と指定されているためcssのみで指定できない。そのためthemeのjsで固有のclass`aw_lgcQueries`を指定している
+    fieldset {
+      @apply mt-4 py-2 px-4 rounded-md
+    }
+
+    fieldset legend {
+      @apply text-xs font-bold
+    }
+
+    .lgc-queryForm-months {
+      @apply w-[3.5rem]
+    }
+  }
+
   // EVM
   .controller-project_evms {
     #levm_query_form fieldset {

--- a/src/sass/components/form.scss
+++ b/src/sass/components/form.scss
@@ -23,7 +23,7 @@
   }
 
   input[type="checkbox"] {
-    @apply h-auto align-baseline
+    @apply h-auto align-text-bottom
   }
 
   input:not([type="checkbox"], [type="radio"], [type="submit"]) {

--- a/src/sass/components/label.scss
+++ b/src/sass/components/label.scss
@@ -14,7 +14,7 @@
   label.inline {
     margin-left: 0 !important;
 
-    @apply inline-flex items-center w-auto text-sm text-text-default text-left mr-4 mb-0
+    @apply w-auto text-sm text-text-default text-left mr-4 mb-0
   }
 
   .tabular label.inline {
@@ -36,6 +36,9 @@
     @apply mr-1
   }
 
+  .tabular label.inline input[type="checkbox"] {
+    @apply mt-0
+  }
 
   .query-columns + p .inline:first-of-type {
     background-color: #f00;


### PR DESCRIPTION
Lycheeガントチャートのカスタムクエリ作成画面の対応を行った。
このページはbodyのclassで判定できなかった（bodyのclassにスラッシュ（`/`）が入っており、cssのみで指定ができなかった）ため、テーマjsから特定可能なclassを追加している。