### PR TITLE
Fix 83080 チケットやカテゴリ、バージョンを追加する「＋」ボタンから展開されるUIの挙動がおかしい

### DIFF
--- a/src/sass/components/buttons.scss
+++ b/src/sass/components/buttons.scss
@@ -191,7 +191,7 @@
 
     background-image: url(images/add_dark.svg);
 
-    @apply block bg-no-repeat bg-[length:16px_16px] bg-center mb-4 ml-3.5
+    @apply block bg-no-repeat bg-[length:16px_16px] bg-center
   }
 
   #main-menu li a.new-object:hover,

--- a/src/sass/components/mainMenu.scss
+++ b/src/sass/components/mainMenu.scss
@@ -92,12 +92,16 @@
   }
 
   // main-menu > new-object
+  #main-menu ul li:has(.new-object) {
+    @apply left-3 w-6 mb-4
+  }
+
   #main-menu .menu-children {
     @apply hidden fixed w-auto bg-background-primary border border-border-default p-1 rounded-md shadow-lg z-[1]
   }
 
-  #main-menu .new-object:hover + ul.menu-children,
+  #main-menu li:hover ul.menu-children,
   #main-menu li ul.menu-children.visible {
-    @apply left-2 block w-[11rem] -mt-3
+    @apply left-2 block w-[11rem]
   }
 }


### PR DESCRIPTION
展開されたメニューがプラスボタンから離れていた位置にあったため、マウスが離れると閉じてしまっていた。
→ポジションを調整

実際のプラスボタンよりも大きいサイズにマウスオーバーの判定がかかっていたため、プラスボタンの周囲にマウスオーバーするとメニューが展開されていたので、cssの指定方法を変更した