### PR TITLE
Fix 83216 【4.1系のみ】メインメニューが見切れる場合に表示されるページ送りボタンが見えてしまっている

### DIFF
--- a/src/js/index.js
+++ b/src/js/index.js
@@ -1,7 +1,11 @@
-// .tabs-buttons(main menuが見切れる時のページ送りUI)を非表示にする(HTMLのstyle属性でして押されておりテーマcssで上書きできないため)
+// .tabs-buttons(main menuが見切れる時のページ送りUI)を非表示にする
+// Note: HTMLのstyle属性でして押されておりテーマcssで上書きできないため、テーマjsで上書きする
 function hiddenTabsButtons() {
   const tabsButton = document.querySelector('#main-menu .tabs-buttons')
-  if(tabsButton) tabsButton.classList.remove('tabs-buttons')
+  if(tabsButton) {
+    tabsButton.classList.remove('tabs-buttons')
+    tabsButton.style.display = 'none'
+  }
 }
 
 function setMainMenuTop() {

--- a/src/sass/components/mainMenu.scss
+++ b/src/sass/components/mainMenu.scss
@@ -87,10 +87,6 @@
     @apply bg-primitive-darkGray-900
   }
 
-  #main-menu .tabs-buttons {
-    @apply opacity-0
-  }
-
   // main-menu > new-object
   #main-menu .menu-children {
     @apply hidden fixed w-auto bg-background-primary border border-border-default p-1 rounded-md shadow-lg z-[1]


### PR DESCRIPTION
メインメニューの数が多いときに表示される表示送りのボタンについて、Lycheeテーマベーシックではメインメニューが縦スクロールになるため不要となった。
そのため、非表示にする対応を行っていたが、4.1系では表示送りボタンが表示されていた。
その対応。