### PR TITLE
FIX 82274 【4.1系のみ】チケット一覧などで右クリックで展開されるメニューで、チェックされている選択肢のチェックアイコンがリピート表示されてしまう

### DIFF
--- a/src/sass/components/context_menu.scss
+++ b/src/sass/components/context_menu.scss
@@ -1,28 +1,14 @@
 #context-menu { position: absolute; z-index: 40; font-size: 0.9em;}
 
-#context-menu ul, #context-menu li, #context-menu a {
-  // display:block;
-  // margin:0;
-  // padding:0;
-  // border:0;
-}
-
-#context-menu ul {
-  // width: 150px;
-}
-
 #context-menu li {
   position:relative;
   padding:1px;
   z-index:39;
   border:1px solid white;
 }
-// #context-menu li.folder ul { position:absolute; left:168px; /* IE6 */ top:-2px; max-height:300px; overflow:hidden; overflow-y: auto; }
-// #context-menu li.folder>ul { left:148px; }
 
 #context-menu.reverse-y li.folder>ul, #context-menu li.folder.up>ul { top:auto; bottom:0; }
 #context-menu.reverse-x li.folder ul { left:auto; right:168px; /* IE6 */ }
-// #context-menu.reverse-x li.folder>ul { right:148px; }
 
 #context-menu.reverse-y li.folder.down>ul {
   position:absolute; top:-2px; bottom: auto; max-height:300px; overflow:hidden; overflow-y: auto;
@@ -36,12 +22,10 @@
 #context-menu li>a { width:auto; } /* others */
 #context-menu a.disabled, #context-menu a.disabled:hover {color: #aaa;}
 #context-menu li a.submenu { padding-right:16px; background:url("../images/arrow_right.png") right no-repeat; }
-// #context-menu li:hover { border:1px solid #628db6; background-color:#eef5fd; border-radius:3px; }
-// #context-menu a:hover {color:#2A5685;}
 #context-menu li.folder:hover { z-index:40; }
 #context-menu ul ul, #context-menu  li:hover ul ul { display:none; }
 #context-menu li:hover ul, #context-menu li:hover li:hover ul { display:block; }
-#context-menu a.icon-checked {background-position: 3px 40%;}
+#context-menu a.icon-checked {background-position: 3px 40%; background-repeat: no-repeat;}
 
 /* selected element */
 .context-menu-selection { background-color:#507AAA; color:#f8f8f8; }
@@ -53,8 +37,7 @@ div#gantt_area .context-menu-selection a { color: #169; }
 
 @layer components {
   #context-menu ul {
-    // width: 180px;
-    @apply w-[180px] bg-background-primary border border-solid border-border-default rounded-md shadow-lg m-0 p-1
+    @apply w-[180px] bg-background-primary border border-solid border-border-default rounded-md shadow-lg m-0 p-0.5
   }
 
   #context-menu li {
@@ -71,7 +54,6 @@ div#gantt_area .context-menu-selection a { color: #169; }
 
   #context-menu li.folder ul {
     position:absolute;
-    // left:168px;
     top:-2px;
     max-height:300px;
     overflow:hidden;


### PR DESCRIPTION
4.1.7環境だとチケット一覧等のコンテキストメニュー（右クリックで展開されるメニュー）のチェックされている選択肢に表示されるチェックアイコンがリピート表示されていた問題に対処した。