### PR TITLE
FIX 82898 Lycheeガントチャートのカレンダーの西暦入力フォームが見切れている

### DIFF
--- a/src/sass/application.scss
+++ b/src/sass/application.scss
@@ -53,6 +53,7 @@
 @use './components/label.scss' as *;
 @use './components/fieldset.scss' as *;
 @use './components/query.scss' as *;
+@use './components/jqueryUi.scss' as *;
 
 // Pages
 @use './pages/login.scss' as *;

--- a/src/sass/components/jqueryUi.scss
+++ b/src/sass/components/jqueryUi.scss
@@ -1,0 +1,6 @@
+@layer components {
+  .ui-datepicker select.ui-datepicker-month,
+  .ui-datepicker select.ui-datepicker-year {
+    @apply text-sm
+  }
+}


### PR DESCRIPTION
Lycheeガントチャートのチケット編集ダイアログにて、開始日期日等を入力するためのカレンダーUIを開いたとき、西暦入力フォームの値がわずかに見切れていることがあったため修正