### PR TITLE
FIX 82883 ダッシュボードの初期に表示されるパネルのコピーアイコンと各パネルの保存ボタンの色や余白が不自然（他のボタンと一貫性がない）

### DIFF
--- a/src/sass/components/buttons.scss
+++ b/src/sass/components/buttons.scss
@@ -227,6 +227,13 @@
     @apply bg-[left_center] text-xs pr-2 pl-4 py-1 shadow-none
   }
 
+  // Lychee Project Dashboardの「コピー」ボタン
+  .controller-lychee_project_dashboards {
+    #content button[type="submit"] {
+      @apply cursor-pointer bg-product-default text-text-onFill hover:bg-product-hover
+    }
+  }
+
   // 管理→設定のフィルタ(filter.scssも参照)
   // 設定 > プロジェクト
   // 設定 > ユーザー

--- a/src/sass/plugins/lychee.scss
+++ b/src/sass/plugins/lychee.scss
@@ -39,6 +39,13 @@
     @apply mt-2
   }
 
+  // Lychee Project Dashboardの「コピー」ボタン
+  .controller-lychee_project_dashboards {
+    #content button[type="submit"] + button {
+      @apply ml-1
+    }
+  }
+
 
   // LRM
   .controller-resource_management {


### PR DESCRIPTION
Primaryボタンとして指定しているはずのボタン（初期UIのコピーボタンや各パネルの保存ボタン）の色が意図した色になっていなかった。また、各パネルの保存ボタンについては、キャンセルボタンとの余白が0で見づらかったのでそれらを修正してボタンの一貫性を揃えた。