### PR TITLE
FIX 82896 経費のフィルターの「年月」と「Nヶ月分」のフォームについて、カレンダーアイコンや矢印の右側に不自然な余白がある

### DIFF
--- a/src/sass/components/filter.scss
+++ b/src/sass/components/filter.scss
@@ -593,7 +593,7 @@
   .controller-lychee_cost_expenses {
     #lychee_cost_expenses {
       #month, #x_months {
-        @apply text-xs py-1 pr-6 pl-2 my-0
+        @apply text-xs py-1 px-2 my-0
       }
     }
   }


### PR DESCRIPTION
日付フォームのカレンダーアイコンや、範囲選択の上下三角アイコンの右側に不自然な余白が発生していたため対応