### PR TITLE
FIX 83268 リソースマネジメントのカスタムクエリ作成画面の「集計対象項目」がスマホ表示だと見づらい

### DIFF
--- a/src/sass/responsives/responsive.scss
+++ b/src/sass/responsives/responsive.scss
@@ -976,6 +976,12 @@
       @apply flex flex-col
     }
   }
+
+  .controller-lrm_queries {
+    #group_keys {
+      @apply w-[90%]
+    }
+  }
 }
 
 @media all and (max-width: 599px) {


### PR DESCRIPTION
カスタムクエリ作成画面の「集計対象項目」について
PC表示だと、数字と対応するセレクトボックスが以下のようにレイアウトされているが、
```
集計対象項目
1: [セレクトボックス▼]
2: [セレクトボックス▼]
3: [セレクトボックス▼]
```

スマホ表示だと、以下のように縦に並んでいる
```
集計対象項目
1:
[セレクトボックス▼]
2:
[セレクトボックス▼]
3:
[セレクトボックス▼]
```
縦並びになると、どのセレクトボックスが何番かが分かりづらくなるため、スマホ表示でも横並びになるように変更した