### PR TITLE
FIX 83267 リソースマネジメントの割当て稼働時間の設定・背景色閾値の設定の、表と保存ボタンの余白がない

### DIFF
--- a/src/sass/plugins/lychee.scss
+++ b/src/sass/plugins/lychee.scss
@@ -61,6 +61,20 @@
     }
   }
 
+  // LRM: 設定→割当て稼働時間の設定
+  .controller-distributed_workloads {
+    #content input[type="submit"] {
+      @apply mt-2
+    }
+  }
+
+  // LRM: 設定→背景色閾値の設定
+  .controller-threshold_settings {
+    #content input[type="submit"] {
+      @apply mt-2
+    }
+  }
+
 
   // LPR 共通
   .controller-project_report_overview {


### PR DESCRIPTION
リソースマネジメント→設定→割当て稼働時間の設定
リソースマネジメント→設定→背景色閾値の設定
上記ページの、表と保存ボタン間の余白が０だったので修正した。