### PR TITLE
FIX 83266  EVMの日付選択カレンダーの月設定フィールドが段落落ちしている

### DIFF
--- a/src/sass/plugins/lychee.scss
+++ b/src/sass/plugins/lychee.scss
@@ -358,6 +358,15 @@
     @apply ml-0
   }
 
+  // Lychee EVM
+  .controller-project_evms {
+    // 基準日選択datepickerの年月選択フィールドが4.1.7だと段落落ちしているため対応
+    .ui-datepicker .ui-datepicker-year,
+    .ui-datepicker .ui-datepicker-month {
+      @apply w-[45%] text-sm
+    }
+  }
+
   // Lychee Cost
   .lychee-cost-cash-forecast__unit-description {
     @apply top-4 right-4


### PR DESCRIPTION
5.1.2では年月フィールドに`width: 45%;`が指定されているが、4.1.7では`widht: 49%;`となっていたので、5.1.2に合わせた。
また、それだけでは4系で年フィールドの文字が見切れていたため、フォントサイズも調整した。