### PR TITLE
FIX 82773 ライセンス管理画面のボタンの文字や、レイアウトが崩れている

### DIFF
--- a/src/sass/pages/login.scss
+++ b/src/sass/pages/login.scss
@@ -59,7 +59,7 @@
     }
   }
 
-  .action-register {
+  .controller-account.action-register {
     h2 {
       @apply text-lg text-text-default font-bold text-center
     }

--- a/src/sass/responsives/responsive.scss
+++ b/src/sass/responsives/responsive.scss
@@ -982,6 +982,23 @@
       @apply w-[90%]
     }
   }
+
+  .controller-lychee_licenses.controller-lychee_licenses {
+    #new_registration table,
+    #new_registration table thead,
+    #new_registration table tbody,
+    #new_registration table tr {
+      @apply block
+    }
+
+    #new_registration table td {
+      @apply block px-0
+    }
+
+    #new_registration table td + td {
+      @apply pt-0
+    }
+  }
 }
 
 @media all and (max-width: 599px) {


### PR DESCRIPTION
ユーザー登録画面のcssが影響を与えていたため、上書きするように調整。