### PR TITLE
FIX 83557 メッセージボックスのお知らせ欄の行間が狭くて見づらい

### DIFF
--- a/src/sass/plugins/lychee.scss
+++ b/src/sass/plugins/lychee.scss
@@ -633,6 +633,15 @@
     }
   }
 
+  // Message Box → お知らせ・管理者へのお知らせ
+  .controller-lychee_message_box_informations.controller-lychee_message_box_informations,
+  .controller-lychee_message_box_system_errors.controller-lychee_message_box_system_errors {
+    .details-content p ~ p {
+      @apply my-4
+    }
+  }
+
+
 
   // Lychee ライセンス管理
   .controller-lychee_licenses.controller-lychee_licenses {


### PR DESCRIPTION
tailwindcssのリセットによりpタグのmarginが0になっていたことが原因。
お知らせ／管理者からのお知らせのメッセージ内容の行間を確保し、デフォルトテーマと同じような見た目に変更した。