### PR TITLE
FIX 83563 個別プロレポのバージョン選択UIが崩れている

### DIFF
--- a/src/sass/plugins/lychee.scss
+++ b/src/sass/plugins/lychee.scss
@@ -135,8 +135,8 @@
     }
 
     // 各パネルの編集／セッティング／閉じるアイコン用
-    #content span span {
-      @apply ml-1
+    #content span[title="オプション"] {
+      @apply mx-1
     }
 
     // マイルストーンの期間フィールド


### PR DESCRIPTION
`span span`という記述がSearchable Selectboxにも適用されていたため、指定方法を変更した。