### PR TITLE
FIX 82848 【4.1.7】チケット一覧画面でオプションを開いた時のアイコンが変わる

### DIFF
--- a/src/sass/components/filter.scss
+++ b/src/sass/components/filter.scss
@@ -35,6 +35,7 @@
   }
 
   fieldset#options legend.icon-expanded,
+  fieldset#options legend.icon-expended,
   fieldset#options legend.icon-collapsed {
     background-image: url(images/arrow_split_default.svg);
   }


### PR DESCRIPTION
4系と5系で開いているときのclass名が異なっていた
4系: icon-expended
5系: icon-expanded