### PR TITLE
FIX 82851 【4.1.7】チケット詳細画面の作業時間タブだけ表示位置が少し崩れている

### DIFF
--- a/src/sass/components/journal.scss
+++ b/src/sass/components/journal.scss
@@ -11,6 +11,10 @@
     @apply flex items-center ml-6
   }
 
+  .time_entry .contextual + h4:not(.note-header) {
+    @apply flex items-center ml-6
+  }
+
   .journal .note-header .gravatar {
     @apply mr-1
   }


### PR DESCRIPTION
4系の作業時間は他のタブと異なり`.note-header`というclassが存在していなかったのが原因