### PR TITLE
FIX 82845 プロジェクト設定のプロジェクトごとのリストタブ、スマホ表示だと各リストの区切りが分かりづらい

### DIFF
--- a/src/sass/responsives/responsive.scss
+++ b/src/sass/responsives/responsive.scss
@@ -733,6 +733,17 @@
     @apply mt-4
   }
 
+  /* プロジェクトごとのリスト */
+  .controller-projects {
+    #tab-content-per_project_lists ul[id^="per_project_enumerations_"] li:not(:first-child) {
+      @apply mt-3
+    }
+
+    #tab-content-per_project_lists ul[id^="per_project_enumerations_"] input[type="text"] {
+      @apply w-[70%]
+    }
+  }
+
   /* Gantt charts */
   /*
    * [1] override inline styles with important


### PR DESCRIPTION
スマホ表示の際に段落落ちが発生しづらくなるよう、テキストフィールドの横幅を調整