### PR TITLE
FIX 82777  管理→設定→リポジトリの「使用するバージョン管理システム」の表、見出しと項目がズレている

### DIFF
--- a/src/sass/pages/settings.scss
+++ b/src/sass/pages/settings.scss
@@ -42,6 +42,11 @@
     input#settings_issue_list_default_totals_ + .inline {
       @apply pl-2
     }
+
+    /* 管理→設定→リポジトリ */
+    #tab-content-repositories table th {
+      @apply text-left
+    }
   }
 
   .controller-custom_field_categories {


### PR DESCRIPTION
 見出しが中央揃え、項目が左揃えだったので、どちらも左揃えにした。