### PR TITLE
FIX 83880 プロジェクト設定のプロジェクトごとのリストタブ、リスト形式の場合にスマホ表示だと各リストの区切りが分かりづらい

### DIFF
--- a/src/sass/responsives/responsive.scss
+++ b/src/sass/responsives/responsive.scss
@@ -742,6 +742,14 @@
     #tab-content-per_project_lists ul[id^="per_project_enumerations_"] input[type="text"] {
       @apply w-[70%]
     }
+
+    #tab-content-per_project_lists div[id^="possible_values_list_"] > div:not(:first-child) {
+      @apply mt-3
+    }
+
+    #tab-content-per_project_lists div[id^="possible_values_list_"] input[type="text"] {
+      @apply w-[70%]
+    }
   }
 
   /* Gantt charts */


### PR DESCRIPTION
プロジェクト設定→プロジェクトごとのリストタブに表示される対象は以下
- キーバリュー形式のカスタムフィールド
- リスト形式のカスタムフィールド

キーバリュー形式のみ対応していて、リスト形式の対応が漏れていたため修正した。