### PR TITLE
FIX 82831 プロジェクト設定のレポートタブをスマホ表示にすると、レポート作成曜日項目が見づらくなる

### DIFF
--- a/src/sass/responsives/responsive.scss
+++ b/src/sass/responsives/responsive.scss
@@ -1041,6 +1041,18 @@
       @apply w-auto ml-0 pr-0 translate-y-0
     }
   }
+
+  /* Project Report */
+  // プロジェクト設定→レポート
+  .controller-projects {
+    #tab-content-project_report .tabular p {
+      @apply pl-0
+    }
+
+    #tab-content-project_report .tabular label {
+      @apply w-full ml-0
+    }
+  }
 }
 
 @media all and (max-width: 599px) {


### PR DESCRIPTION
原因：プロジェクト設定ページの`.tabular`はスマホ対応していたが、プロジェクトレポートプラグイン側でcssを上書きしていたためレポートタブだけ対応できていなかった。