### PR TITLE
FIX 82872 旧Lycheeガントチャートで、複数選択→編集を押したときのダイアログで、選択したチケットリストの左に不自然な余白が生じている

### DIFF
--- a/src/sass/plugins/lychee.scss
+++ b/src/sass/plugins/lychee.scss
@@ -377,6 +377,11 @@
         @apply text-xs
       }
     }
+
+    // チケットの一括編集
+    .lgc-issueDetail-bulkEdit-issues {
+      @apply list-disc pl-6
+    }
   }
 
   .lgc-is-fullscreen #main {


### PR DESCRIPTION
リストスタイルがリセットcssで消えていたことが原因。
リストスタイルを指定しても左の余白が大きめだったため、余白も一緒に調整した。