### PR TITLE
Feature 87443 ページの下部にいてもPJメニューにすぐアクセスしたい。なぜなら別メニューに遷移しようとすると最上部までスクロールする必要があり手間なので。

### DIFF
--- a/src/js/index.js
+++ b/src/js/index.js
@@ -1,5 +1,6 @@
 import { addDefaultTopMenStyle, initToggleTopMenu } from './topMenu'
 import { addNoHorizonScrollClass, saveMainMenuHorizonScrollPosition, restoreMainMenuHorizonScrollPosition } from './mainMenu'
+import { initializeScrollHandler } from './mainMenuScrollUp'
 import { addDefaultSidebarStyle, initToggleSidebar } from './sidebar'
 import { waitForBilling, checkTrial, copyBillingContainer } from './billing'
 
@@ -169,68 +170,7 @@ window.addEventListener('DOMContentLoaded', () => {
 
 
   /**
-   * 検証用：上にちょっとするクロールするとmain-menuを固定表示にしたい
+   * 上にちょっとするクロールするとmain-menuを固定表示にしたい
    */
-  let lastScrollTop = 0
-  let scrollTimer
-  let hideTimer
-  const wrapper = document.getElementById('wrapper')
-  const SCROLL_THRESHOLD = 80 // PJメニューを表示するまでのスクロール量を指定（この場合一度に15px以上スクロールされたらPJメニューを表示する）
-  const CLASS_NAME = 'scrolled-up'
-  const SHOW_DELAY = 200
-  const HIDE_DELAY = 2000
-
-  const mainMenu = document.getElementById('main-menu')
-  let isMouseOverMainMenu = false
-  mainMenu.addEventListener('mouseenter', () => {
-    isMouseOverMainMenu = true
-    clearTimeout(hideTimer)
-    console.log(isMouseOverMainMenu)
-  })
-
-  mainMenu.addEventListener('mouseleave', () => {
-    isMouseOverMainMenu = false
-    console.log(isMouseOverMainMenu)
-    hideTimer = setTimeout(() => {
-      if (!isMouseOverMainMenu) {
-          wrapper.classList.remove(CLASS_NAME);
-      }
-    }, HIDE_DELAY);
-  })
-
-  window.addEventListener('scroll', () => {
-    clearTimeout(scrollTimer)
-    clearTimeout(hideTimer)
-
-    let scrollTop = window.scrollY || document.documentElement.scrollTop
-    const headerHeight = document.getElementById('header').offsetHeight
-
-    // TODO: PJメニューの表示非表示にフェードかけたいので、それ用のclassを付与したい
-    // header部分が隠れたら、アニメーション用のclassを付与
-    // if(scrollTop > headerHeight) {
-    //   mainMenu.classList.add('fade-in')
-    // }
-
-    if(scrollTop > lastScrollTop || scrollTop <= headerHeight) {
-      // 少しでも下にスクロールした場合はPJメニューを非表示に
-      wrapper.classList.remove(CLASS_NAME)
-      lastScrollTop = scrollTop
-    } else {
-      // スクロール後すぐに出すのではなく、一定時間経過後に表示したい
-      scrollTimer = setTimeout(() => {
-        if(lastScrollTop - scrollTop > SCROLL_THRESHOLD) {
-          wrapper.classList.add(CLASS_NAME)
-        }
-
-        // 一定時間操作がなければ非表示にしたい
-        hideTimer = setTimeout(() => {
-          if(!isMouseOverMainMenu) {
-            wrapper.classList.remove(CLASS_NAME)
-          }
-        }, HIDE_DELAY)
-
-        lastScrollTop = scrollTop
-      }, SHOW_DELAY)
-    }
-  })
+  initializeScrollHandler()
 })

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -195,7 +195,7 @@ window.addEventListener('DOMContentLoaded', () => {
       if (!isMouseOverMainMenu) {
           wrapper.classList.remove(CLASS_NAME);
       }
-  }, HIDE_DELAY);
+    }, HIDE_DELAY);
   })
 
   window.addEventListener('scroll', () => {

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -166,4 +166,71 @@ window.addEventListener('DOMContentLoaded', () => {
   if([...lgcQueriesBodyClasses].includes('controller-lgc/queries')) {
     document.body.classList.add('aw_lgcQueries')
   }
+
+
+  /**
+   * 検証用：上にちょっとするクロールするとmain-menuを固定表示にしたい
+   */
+  let lastScrollTop = 0
+  let scrollTimer
+  let hideTimer
+  const wrapper = document.getElementById('wrapper')
+  const SCROLL_THRESHOLD = 80 // PJメニューを表示するまでのスクロール量を指定（この場合一度に15px以上スクロールされたらPJメニューを表示する）
+  const CLASS_NAME = 'scrolled-up'
+  const SHOW_DELAY = 200
+  const HIDE_DELAY = 2000
+
+  const mainMenu = document.getElementById('main-menu')
+  let isMouseOverMainMenu = false
+  mainMenu.addEventListener('mouseenter', () => {
+    isMouseOverMainMenu = true
+    clearTimeout(hideTimer)
+    console.log(isMouseOverMainMenu)
+  })
+
+  mainMenu.addEventListener('mouseleave', () => {
+    isMouseOverMainMenu = false
+    console.log(isMouseOverMainMenu)
+    hideTimer = setTimeout(() => {
+      if (!isMouseOverMainMenu) {
+          wrapper.classList.remove(CLASS_NAME);
+      }
+  }, HIDE_DELAY);
+  })
+
+  window.addEventListener('scroll', () => {
+    clearTimeout(scrollTimer)
+    clearTimeout(hideTimer)
+
+    let scrollTop = window.scrollY || document.documentElement.scrollTop
+    const headerHeight = document.getElementById('header').offsetHeight
+
+    // TODO: PJメニューの表示非表示にフェードかけたいので、それ用のclassを付与したい
+    // header部分が隠れたら、アニメーション用のclassを付与
+    // if(scrollTop > headerHeight) {
+    //   mainMenu.classList.add('fade-in')
+    // }
+
+    if(scrollTop > lastScrollTop || scrollTop <= headerHeight) {
+      // 少しでも下にスクロールした場合はPJメニューを非表示に
+      wrapper.classList.remove(CLASS_NAME)
+      lastScrollTop = scrollTop
+    } else {
+      // スクロール後すぐに出すのではなく、一定時間経過後に表示したい
+      scrollTimer = setTimeout(() => {
+        if(lastScrollTop - scrollTop > SCROLL_THRESHOLD) {
+          wrapper.classList.add(CLASS_NAME)
+        }
+
+        // 一定時間操作がなければ非表示にしたい
+        hideTimer = setTimeout(() => {
+          if(!isMouseOverMainMenu) {
+            wrapper.classList.remove(CLASS_NAME)
+          }
+        }, HIDE_DELAY)
+
+        lastScrollTop = scrollTop
+      }, SHOW_DELAY)
+    }
+  })
 })

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -1,5 +1,5 @@
 import { addDefaultTopMenStyle, initToggleTopMenu } from './topMenu'
-import { addNoScrollClass, saveMainMenuScrollPosition, restoreMainMenuScrollPosition } from './mainMenu'
+import { addNoHorizonScrollClass, saveMainMenuHorizonScrollPosition, restoreMainMenuHorizonScrollPosition } from './mainMenu'
 import { addDefaultSidebarStyle, initToggleSidebar } from './sidebar'
 import { waitForBilling, checkTrial, copyBillingContainer } from './billing'
 
@@ -52,9 +52,9 @@ function addFeedbackLink() {
 /**
  * MainMenuの横スクロールに関する処理
  */
-window.addEventListener('resize', addNoScrollClass)
-window.addEventListener('beforeunload', saveMainMenuScrollPosition);
-window.addEventListener('load', restoreMainMenuScrollPosition);
+window.addEventListener('resize', addNoHorizonScrollClass)
+window.addEventListener('beforeunload', saveMainMenuHorizonScrollPosition);
+window.addEventListener('load', restoreMainMenuHorizonScrollPosition);
 
 /**
  * その他一般的な処理
@@ -77,7 +77,7 @@ window.addEventListener('DOMContentLoaded', () => {
   /**
    * MainMenuの調整
    */
-  addNoScrollClass()
+  addNoHorizonScrollClass()
 
 
   /**

--- a/src/js/mainMenu.js
+++ b/src/js/mainMenu.js
@@ -1,8 +1,8 @@
-function isMenuExists() {
+function isPJMenuExists() {
   return document.querySelector('#main-menu > ul:not(.menu-children)') !== null
 }
 
-function getMainMenu() {
+function getPJMenu() {
   return document.querySelector('#main-menu > ul:not(.menu-children)')
 }
 
@@ -10,10 +10,15 @@ function isHorizonScrollable(scrollContainer) {
   return scrollContainer.scrollWidth > scrollContainer.clientWidth
 }
 
-export function addNoHorizonScrollClass() {
-  if(!isMenuExists()) return
 
-  const container = getMainMenu()
+/**
+ * PJメニュー横スクロール関連の処理
+ */
+/* 横スクロール用classの付与 */
+export function addNoHorizonScrollClass() {
+  if(!isPJMenuExists()) return
+
+  const container = getPJMenu()
   if(isHorizonScrollable(container)) {
     container.classList.remove('noScroll')
   } else {
@@ -27,10 +32,11 @@ function initHorizonScrollPosition() {
   localStorage.setItem('mainMenuHorizonScrollPosition', 0)
 }
 
+/* 横スクロール位置の記憶 */
 export function saveMainMenuHorizonScrollPosition() {
-  if(!isMenuExists()) return
+  if(!isPJMenuExists()) return
 
-  const mainMenu = getMainMenu()
+  const mainMenu = getPJMenu()
 
   // スクロールが発生しない場合は初期化して終わり
   if(!isHorizonScrollable(mainMenu)) {
@@ -42,10 +48,11 @@ export function saveMainMenuHorizonScrollPosition() {
   localStorage.setItem('mainMenuHorizonScrollPosition', mainMenu.scrollLeft)
 }
 
+/* 横スクロール位置の復原 */
 export function restoreMainMenuHorizonScrollPosition() {
-  if(!isMenuExists()) return
+  if(!isPJMenuExists()) return
 
-  const mainMenu = getMainMenu()
+  const mainMenu = getPJMenu()
 
   // スクロールが発生しない場合は初期化して終わり
   if(!isHorizonScrollable(mainMenu)) {

--- a/src/js/mainMenu.js
+++ b/src/js/mainMenu.js
@@ -6,15 +6,15 @@ function getMainMenu() {
   return document.querySelector('#main-menu > ul:not(.menu-children)')
 }
 
-function isScrollable(scrollContainer) {
+function isHorizonScrollable(scrollContainer) {
   return scrollContainer.scrollWidth > scrollContainer.clientWidth
 }
 
-export function addNoScrollClass() {
+export function addNoHorizonScrollClass() {
   if(!isMenuExists()) return
 
   const container = getMainMenu()
-  if(isScrollable(container)) {
+  if(isHorizonScrollable(container)) {
     container.classList.remove('noScroll')
   } else {
     container.classList.add('noScroll')
@@ -23,38 +23,38 @@ export function addNoScrollClass() {
 
 
 /* ページを遷移しても横スクロール位置を覚えておきたい */
-function initScrollPosition() {
-  localStorage.setItem('mainMenuScrollPosition', 0)
+function initHorizonScrollPosition() {
+  localStorage.setItem('mainMenuHorizonScrollPosition', 0)
 }
 
-export function saveMainMenuScrollPosition() {
+export function saveMainMenuHorizonScrollPosition() {
   if(!isMenuExists()) return
 
   const mainMenu = getMainMenu()
 
   // スクロールが発生しない場合は初期化して終わり
-  if(!isScrollable(mainMenu)) {
-    initScrollPosition()
+  if(!isHorizonScrollable(mainMenu)) {
+    initHorizonScrollPosition()
     return
   }
 
   // スクロールが発生する場合は位置を記録
-  localStorage.setItem('mainMenuScrollPosition', mainMenu.scrollLeft)
+  localStorage.setItem('mainMenuHorizonScrollPosition', mainMenu.scrollLeft)
 }
 
-export function restoreMainMenuScrollPosition() {
+export function restoreMainMenuHorizonScrollPosition() {
   if(!isMenuExists()) return
 
   const mainMenu = getMainMenu()
 
   // スクロールが発生しない場合は初期化して終わり
-  if(!isScrollable(mainMenu)) {
-    initScrollPosition()
+  if(!isHorizonScrollable(mainMenu)) {
+    initHorizonScrollPosition()
     return
   }
 
   // スクロールが発生する場合は復原
-  const scrollPosition = localStorage.getItem('mainMenuScrollPosition')
+  const scrollPosition = localStorage.getItem('mainMenuHorizonScrollPosition')
   if(scrollPosition) {
     mainMenu.scrollLeft = scrollPosition
   }

--- a/src/js/mainMenuScrollUp.js
+++ b/src/js/mainMenuScrollUp.js
@@ -1,0 +1,80 @@
+import {
+  isMainMenuExists,
+  isHeaderShow,
+  getWrapper, getHeader, getMainMenu
+} from './utility'
+
+/**
+ * PJメニューを上スクロールで表示するための処理
+ */
+const SCROLL_THRESHOLD = 80 // PJメニューをスクロールするまでのスクロール量（一度に80px以上スクロールされた場合PJメニューを表示したい）
+const CLASS_NAME = 'scrolled-up'
+const SHOW_DELAY = 200
+const HIDE_DELAY = 2000
+
+let lastScrollTop = 0
+let scrollTimer
+let hideTimer
+let isMouseOverMainMenu = false
+
+function onMouseEnter() {
+  isMouseOverMainMenu = true
+  clearTimeout(hideTimer)
+}
+
+function onMouseLeave() {
+  const wrapper = getWrapper()
+
+  isMouseOverMainMenu = false
+  hideTimer = setTimeout(() => {
+    if(!isMouseOverMainMenu) {
+      wrapper.classList.remove(CLASS_NAME)
+    }
+  }, HIDE_DELAY)
+}
+
+function onScroll() {
+  const wrapper = getWrapper()
+  const header = getHeader()
+
+  clearTimeout(scrollTimer)
+  clearTimeout(hideTimer)
+
+  let scrollTop = window.scrollY || document.documentElement.scrollTop
+  const headerHeight = header.offsetHeight
+
+  if (scrollTop > lastScrollTop || scrollTop <= headerHeight) {
+    // 少しでも下にスクロールした場合はPJメニューを非表示に
+    wrapper.classList.remove(CLASS_NAME)
+    lastScrollTop = scrollTop
+  } else {
+    // スクロール後すぐに出すのではなく、一定時間経過後に表示したい
+    scrollTimer = setTimeout(() => {
+      if (lastScrollTop - scrollTop > SCROLL_THRESHOLD) {
+        wrapper.classList.add(CLASS_NAME)
+      }
+
+      // 一定時間操作がなければ非表示にしたい
+      hideTimer = setTimeout(() => {
+        if (!isMouseOverMainMenu) {
+          wrapper.classList.remove(CLASS_NAME)
+        }
+      }, HIDE_DELAY)
+
+      lastScrollTop = scrollTop
+    }, SHOW_DELAY)
+  }
+}
+
+export function initializeScrollHandler() {
+  // mainMenuがそもそも存在しないページ（ホームやログアウト中など）は処理を実行したくない
+  if(!isMainMenuExists()) return
+  const mainMenu = getMainMenu()
+
+  // headerを非表示にしているページ（LRMやLPRなど）も処理を実行したくない
+  if(!isHeaderShow()) return
+
+  mainMenu.addEventListener('mouseenter', onMouseEnter);
+  mainMenu.addEventListener('mouseleave', onMouseLeave);
+  window.addEventListener('scroll', onScroll);
+}

--- a/src/js/mainMenuScrollUp.js
+++ b/src/js/mainMenuScrollUp.js
@@ -1,4 +1,5 @@
 import {
+  isMobile,
   isMainMenuExists,
   isHeaderShow,
   getWrapper, getHeader, getMainMenu
@@ -66,15 +67,36 @@ function onScroll() {
   }
 }
 
-export function initializeScrollHandler() {
+function addEventListeners() {
+  const mainMenu = getMainMenu()
+  mainMenu.addEventListener('mouseenter', onMouseEnter)
+  mainMenu.addEventListener('mouseleave', onMouseLeave)
+  window.addEventListener('scroll', onScroll)
+}
+
+function removeEventListeners() {
+  const mainMenu = getMainMenu()
+  mainMenu.removeEventListener('mouseenter', onMouseEnter)
+  mainMenu.removeEventListener('mouseleave', onMouseLeave)
+  window.removeEventListener('scroll', onScroll)
+}
+
+function checkAndInitialize() {
   // mainMenuがそもそも存在しないページ（ホームやログアウト中など）は処理を実行したくない
   if(!isMainMenuExists()) return
-  const mainMenu = getMainMenu()
 
   // headerを非表示にしているページ（LRMやLPRなど）も処理を実行したくない
   if(!isHeaderShow()) return
 
-  mainMenu.addEventListener('mouseenter', onMouseEnter);
-  mainMenu.addEventListener('mouseleave', onMouseLeave);
-  window.addEventListener('scroll', onScroll);
+  // スマートフォン用表示かどうかチェック
+  if (isMobile()) {
+    removeEventListeners()
+  } else {
+    addEventListeners()
+  }
+}
+
+export function initializeScrollHandler() {
+  checkAndInitialize()
+  window.addEventListener('resize', checkAndInitialize)
 }

--- a/src/js/utility.js
+++ b/src/js/utility.js
@@ -1,0 +1,33 @@
+/**
+ * 要素が存在するかどうか
+ */
+export function isMainMenuExists() {
+  return document.getElementById('main-menu') !== null
+}
+
+
+/**
+ * 要素が表示されているかどうか
+ */
+export function isHeaderShow() {
+  // console.log(document.getElementById('header').style)
+  const header = getHeader()
+  if(header === null) return false
+  return window.getComputedStyle(header).display !== 'none'
+}
+
+
+/**
+ * 要素の取得
+ */
+export function getWrapper() {
+  return document.getElementById('wrapper')
+}
+
+export function getHeader() {
+  return document.getElementById('header')
+}
+
+export function getMainMenu() {
+  return document.getElementById('main-menu')
+}

--- a/src/js/utility.js
+++ b/src/js/utility.js
@@ -1,4 +1,13 @@
 /**
+ * モバイル用のcssが適用されているか
+ */
+export function isMobile() {
+  const mediaQueryList = window.matchMedia('(max-width: 899px)')
+  return mediaQueryList.matches
+}
+
+
+/**
  * 要素が存在するかどうか
  */
 export function isMainMenuExists() {
@@ -10,7 +19,6 @@ export function isMainMenuExists() {
  * 要素が表示されているかどうか
  */
 export function isHeaderShow() {
-  // console.log(document.getElementById('header').style)
   const header = getHeader()
   if(header === null) return false
   return window.getComputedStyle(header).display !== 'none'

--- a/src/sass/components/mainMenu.scss
+++ b/src/sass/components/mainMenu.scss
@@ -3,6 +3,15 @@
     @apply relative w-full bg-background-primary py-1 px-2
   }
 
+  .scrolled-up #main-menu {
+    width: calc(100% - 52px);
+    @apply fixed top-0 left-[52px] z-[999] shadow
+  }
+
+  #wrapper.scrolled-up {
+    @apply pt-[52px]
+  }
+
   /* MainMenuのスタイル */
   #main-menu ul:not(.menu-children) {
     @apply relative flex w-full whitespace-nowrap m-0

--- a/src/sass/components/mainMenu.scss
+++ b/src/sass/components/mainMenu.scss
@@ -3,9 +3,16 @@
     @apply relative w-full bg-background-primary py-1 px-2
   }
 
+  // topMenuを閉じているとき
   .scrolled-up #main-menu {
     width: calc(100% - 52px);
-    @apply fixed top-0 left-[52px] z-[999] shadow
+    @apply fixed top-0 left-[52px] z-[699] border-b border-border-default
+  }
+
+  // topMenuを開いているとき
+  .isTopMenuOpen .scrolled-up #main-menu {
+    width: calc(100% - 180px);
+    @apply left-[180px]
   }
 
   #wrapper.scrolled-up {


### PR DESCRIPTION
・上方向に一定px以上スクロールされたらPJメニューを表示する
・PJメニュー表示後、PJメニューにカーソルがのっている間はPJメニューを表示する
・PJメニュー表示後、PJメニューが操作されなければ非表示にする