### PR TITLE
管理トップのメニューを2カラムに変更

### DIFF
--- a/src/sass/application.scss
+++ b/src/sass/application.scss
@@ -56,6 +56,7 @@
 @use './components/jqueryUi.scss' as *;
 
 // Pages
+@use './pages/admin.scss' as *;
 @use './pages/login.scss' as *;
 @use './pages/activities.scss' as *;
 @use './pages/calendar.scss' as *;

--- a/src/sass/components/sidebar.scss
+++ b/src/sass/components/sidebar.scss
@@ -114,14 +114,6 @@
   }
 
   // adminMenu
-  #admin-index {
-    @apply mt-4
-  }
-
-  #admin-index #admin-menu {
-    @apply max-w-xs
-  }
-
   #admin-menu ul {
     @apply p-0
   }

--- a/src/sass/pages/admin.scss
+++ b/src/sass/pages/admin.scss
@@ -3,22 +3,15 @@
     @apply bg-background-secondary mt-4 p-1.5 rounded-lg 
   }
 
-  #admin-index #admin-menu {
-  }
-
   #admin-index #admin-menu ul {
-    @apply grid grid-cols-[repeat(auto-fit,_minmax(220px,_1fr))] gap-1.5
-  }
-
-  #admin-index #admin-menu ul li {
-    @apply min-h-[50px]
+    @apply columns-3 gap-1.5
   }
 
   #admin-index #admin-menu ul li:not(:first-child) {
-    @apply mt-0
+    @apply mt-1.5
   }
 
   #admin-index #admin-menu ul li a {
-    @apply grid items-center h-full bg-background-primary bg-[12px_center] border border-border-divider text-xs pr-3 pl-8 rounded-md shadow-sm hover:bg-background-primary/50 hover:shadow-none
+    @apply grid items-center min-h-[60px] bg-background-primary bg-[12px_center] border border-border-divider text-xs pr-3 pl-8 rounded-md shadow-sm hover:bg-background-primary/50 hover:shadow-none
   }
 }

--- a/src/sass/pages/admin.scss
+++ b/src/sass/pages/admin.scss
@@ -1,0 +1,13 @@
+@layer components {
+  #admin-index {
+    @apply mt-4
+  }
+
+  #admin-index #admin-menu {
+    @apply max-w-4xl
+  }
+
+  #admin-index #admin-menu ul {
+    @apply columns-2 columns-[300px]
+  }
+}

--- a/src/sass/pages/admin.scss
+++ b/src/sass/pages/admin.scss
@@ -1,13 +1,24 @@
 @layer components {
   #admin-index {
-    @apply mt-4
+    @apply bg-background-secondary mt-4 p-1.5 rounded-lg 
   }
 
   #admin-index #admin-menu {
-    @apply max-w-4xl
   }
 
   #admin-index #admin-menu ul {
-    @apply columns-2 columns-[300px]
+    @apply grid grid-cols-[repeat(auto-fit,_minmax(220px,_1fr))] gap-1.5
+  }
+
+  #admin-index #admin-menu ul li {
+    @apply min-h-[50px]
+  }
+
+  #admin-index #admin-menu ul li:not(:first-child) {
+    @apply mt-0
+  }
+
+  #admin-index #admin-menu ul li a {
+    @apply grid items-center h-full bg-background-primary bg-[12px_center] border border-border-divider text-xs pr-3 pl-8 rounded-md shadow-sm hover:bg-background-primary/50 hover:shadow-none
   }
 }

--- a/src/sass/responsives/responsive.scss
+++ b/src/sass/responsives/responsive.scss
@@ -627,6 +627,10 @@
     @apply content-none
   }
 
+  #admin-index #admin-menu ul {
+    @apply columns-1
+  }
+
   /*----------------------------------------*\
     E) UX ELEMENTS
   \*----------------------------------------*/

--- a/src/sass/responsives/responsive.scss
+++ b/src/sass/responsives/responsive.scss
@@ -607,14 +607,6 @@
     @apply bg-transparent
   }
 
-  #admin-index #admin-menu {
-    @apply max-w-xs
-  }
-
-  #admin-index #admin-menu ul {
-    @apply columns-1
-  }
-
   #admin-menu {
     padding-left: 0;
   }

--- a/src/sass/responsives/responsive.scss
+++ b/src/sass/responsives/responsive.scss
@@ -607,6 +607,14 @@
     @apply bg-transparent
   }
 
+  #admin-index #admin-menu {
+    @apply max-w-xs
+  }
+
+  #admin-index #admin-menu ul {
+    @apply columns-1
+  }
+
   #admin-menu {
     padding-left: 0;
   }


### PR DESCRIPTION
Lycheeテーマベーシックでは余白やフォントサイズを大きくしたため、今まで1画面内に収まっていた管理メニュー群が見切れるようになってしまった。
1画面でメニューをすべて見れるように、2カラムレイアウトに変更した