### PR TITLE
Fix 86172 管理設定や個人ユーザーの編集画面でサイドバーを閉じると、コンテンツはそんなに無いのにスクロールが発生する

### DIFF
--- a/src/js/sidebar.js
+++ b/src/js/sidebar.js
@@ -8,6 +8,7 @@ const sidebarOpenStyle = `
   #sidebar.isSidebarClose {
     width: 0;
     padding-right: 0;
+    white-space: nowrap;
   }
 `
 
@@ -16,6 +17,7 @@ const sidebarCloseStyle = `
     width: 0px;
     padding-right: 0;
     padding-left: 1rem;
+    white-space: nowrap;
   }
 
   #sidebar *:not(.aw_toggleSidebar) {


### PR DESCRIPTION
ブランチ名には89938とあるが、過去すでに起票済みだったのでそちらのチケットに統合したため、名前も86172に変更した