### PR TITLE
Fix 92211 カスタムクエリの解除アイコンにマウスオーバーしてもツールチップが正常に表示されない

### DIFF
--- a/src/sass/components/sidebar.scss
+++ b/src/sass/components/sidebar.scss
@@ -72,6 +72,10 @@
     @apply list-none flex items-center m-0 p-0
   }
 
+  #sidebar ul li:has(.icon-clear-query) {
+    @apply gap-1
+  }
+
   ul.flat li {
     list-style-type: none;
     margin: 0px 2px 0px 0px;
@@ -95,7 +99,7 @@
   }
 
   #sidebar a.icon-only {
-    @apply flex grow-0 overflow-hidden indent-[100%] whitespace-nowrap w-4 h-4 bg-no-repeat bg-[length:16px_16px] ml-1
+    @apply flex grow-0 shrink-0 overflow-hidden indent-[100%] whitespace-nowrap w-[26px] h-5 bg-no-repeat bg-center bg-[length:16px_16px]
   }
 
   #sidebar p {

--- a/src/sass/redmine_default.css
+++ b/src/sass/redmine_default.css
@@ -1005,6 +1005,8 @@ button.tab-left.disabled, button.tab-right.disabled {
   border: 0;
   box-shadow: none;
   white-space: pre-wrap;
+  font-size: 12px;
+  padding: 4px 6px;
 }
 
 


### PR DESCRIPTION
ツールチップの表示位置がクリアボタンの真上に来てしまうことが原因。

詳しくは以下
1. クリアボタンにマウスオーバーすると真上にツールチップが表示される
2. 真上にツールチップが表示されることで、クリアボタンのマウスオーバー判定が解除されてしまう
3. クリアボタンのマウスオーバー判定が解除された結果、ツールチップが非表示になる
4. ツールチップが非表示になったことで、再びクリアボタンにマウスオーバー判定がされ、ツールチップが表示される
5. 以降1〜4を繰り返すことで、ツールチップが表示されず、マウスカーソルだけが切り替わり続ける