### PR TITLE
Fix #106993 【Redmine6.1】整形済みテキストをコピーしたことが、視覚的に分かるアイコン表示になるとうれしい

### DIFF
--- a/src/sass/components/icons.scss
+++ b/src/sass/components/icons.scss
@@ -660,6 +660,12 @@ a.group:has(svg.icon-svg) {
   background-size: 12px;
 }
 
+// 整形済みテキストのコピー後のインタラクション（アイコンがチェックに変わる）に対応
+.pre-wrapper .copy-pre-content-link:has(svg use[href$="#icon--checked"]) {
+  background-image: url(images/done_success.svg);
+}
+
+
 /*
 * Plugins
 */


### PR DESCRIPTION
メモ：
デフォルトテーマでは、svgアイコン自体を差し替えることでコピー完了インタラクションに対応しているが、
lychee theme basicではsvgアイコンを非表示にし、cssでの背景画像を差し込んでいるため、useタグのhref属性の内容によってアイコンを差し替えるように対応した。