### PR TITLE
bamboo orb を追加（初期 CircleCI 設定）

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,26 @@
+version: 2.1
+
+orbs:
+  bamboo: agileware-jp/bamboo@1.1.1
+
+workflows:
+  test:
+    jobs:
+      - bamboo/notify_ci_start:
+          pipeline_number: << pipeline.number >>
+          context:
+            - bamboo
+          filters:
+            branches:
+              only: master
+      - bamboo/notify_ci_end:
+          context:
+            - bamboo
+          filters:
+            branches:
+              only: master
+          # NOTE: 実際の CI ジョブ（rspec, rubocop 等）が追加されたら、
+          # notify_ci_start は requires から外し、追加した CI ジョブを
+          # : terminal 付きで列挙すること。
+          requires:
+            - bamboo/notify_ci_start: terminal


### PR DESCRIPTION
このリポジトリにはまだ CircleCI 設定がなかったため、bamboo orb のみを含む最小構成の .circleci/config.yml を追加しました。実際の CI ジョブが追加されたら、notify_ci_end の requires を更新する必要があります（TODO コメント参照）。