### PR TITLE
fix: LIF iframe等で#top-menu/#accountが描画されない画面のnull参照を防止

### DIFF
--- a/src/js/topMenu.js
+++ b/src/js/topMenu.js
@@ -66,6 +66,8 @@ function addLogoutStyle() {
   // ログアウト中は#loggedasが存在しないので、#accountにmargin-top: auto;を適用したい
   if(!isLoggedIn()) {
     const account = document.getElementById('account')
+    // LIF iframe等、#accountがそもそも描画されないレイアウトでは何もしない
+    if (!account) return
     account.style.marginTop = 'auto'
   }
 }
@@ -195,6 +197,8 @@ export function addFeedbackLink() {
   const BASE_URL = 'https://community.lychee-redmine.jp/projects/lychee-redmine/issues/new'
 
   const topMenuNav = document.querySelector('#top-menu #account ul')
+  // LIF iframe等、#top-menu/#accountが描画されないレイアウトでは何もしない
+  if (!topMenuNav) return
 
   // フィードバックリンクの要素を生成
   const li = document.createElement('li')


### PR DESCRIPTION
## Summary

LIF iframe 用のレイアウト（`lychee_issue_form` の `lif_embedded.html.erb` 等）には `#top-menu` / `#account` / `#loggedas` が存在しない。このため、テーマJSの一部処理がそれらの要素を前提に `null.style` / `null.insertBefore` を呼んでしまい、コンソールに `TypeError` が出ていた。該当箇所に存在チェックを足し、要素が無い画面では何もせず早期 return するようにした。

## 観測されていたエラー

LIF iframe を開いた際にブラウザコンソールに出ていたエラー:

```
theme-9c56da03.js:1 Uncaught TypeError: Cannot read properties of null (reading 'insertBefore')
    at theme-9c56da03.js:1:6903
    at theme-9c56da03.js:1:6939
```

```
theme-756660d0.js:1 Uncaught TypeError: Cannot read properties of null (reading 'style')
    at l (theme-756660d0.js:1:1926)
    at theme-756660d0.js:1:8126
```

それぞれ minified された別箇所だが、原因は同じく LIF レイアウトに対象要素が存在しないこと。

## 変更内容

`src/js/topMenu.js`

- ` addFeedbackLink()` の `document.querySelector('#top-menu #account ul')` の結果に対する null チェックを追加（前者のエラー対策）
- ` addLogoutStyle()` の `document.getElementById('account')` の結果に対する null チェックを追加（後者のエラー対策）

いずれも要素が無い場合は早期 return するだけのガードで、既存の通常レイアウト（top-menu/account あり）には影響しない。

## Test plan

- [x] LIF iframe を含む画面（例: チケット詳細を \`?lif_embedded=1\` 付きで開く）でコンソールに上記2つの TypeError が出ないこと
- [x] 通常画面でヘッダーの「フィードバックを送る」リンクが従来どおり表示されること
<img width="315" height="1357" alt="image" src="https://github.com/user-attachments/assets/1fe0e263-aa1d-4c4a-a93b-2a4dd2e06254" />
<img width="151" height="240" alt="image" src="https://github.com/user-attachments/assets/23889a9b-04d0-459e-9193-bfa9de193c5a" />
- [x] ログアウト状態の通常画面で \`#account\` の margin-top が従来どおり適用されること
<img width="1711" height="1018" alt="image" src="https://github.com/user-attachments/assets/893cb9ea-5014-452f-8d73-16a57e5725f6" />
