### PR TITLE
fix: redmine5.1 でも LIF iframe等のnull参照を防止

### DIFF
--- a/src/js/topMenu.js
+++ b/src/js/topMenu.js
@@ -195,6 +195,8 @@ export function addFeedbackLink() {
   const BASE_URL = 'https://community.lychee-redmine.jp/projects/lychee-redmine/issues/new'
 
   const topMenuNav = document.querySelector('#top-menu #account ul')
+  // LIF iframe等、#top-menu/#accountが描画されないレイアウトでは何もしない
+  if (!topMenuNav) return
 
   // フィードバックリンクの要素を生成
   const li = document.createElement('li')

--- a/src/js/topMenu.js
+++ b/src/js/topMenu.js
@@ -66,6 +66,8 @@ function addLogoutStyle() {
   // ログアウト中は#loggedasが存在しないので、#accountにmargin-top: auto;を適用したい
   if(!isLoggedIn()) {
     const account = document.getElementById('account')
+    // LIF iframe等、#accountが描画されないレイアウトでは何もしない
+    if (!account) return
     account.style.marginTop = 'auto'
   }
 }


### PR DESCRIPTION
## Summary

- PR #257 (master 向け) と同等の null guard を redmine5.1 ブランチにも適用
- LIF iframe 等、`#top-menu/#account` が描画されないレイアウトで `topMenuNav.insertBefore()` が null 参照エラーになっていたのを防ぐ

## Test plan

- [x] paraiso6 の 5.0.14 環境（lychee-theme_Basic redmine5.1ブランチ）で適用後、LIF iframe を開いてもエラーが出ないことを確認

<img width="1702" height="1034" alt="image" src="https://github.com/user-attachments/assets/a10ad034-230b-430f-9124-4043d914d6f2" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)