### PR TITLE
Fix 112904 長いテキストフィールドにテキスト＋リストの形式を書いた場合に、リストがテキストに被るほど上に詰まる場合がある

### DIFF
--- a/src/sass/components/wiki.scss
+++ b/src/sass/components/wiki.scss
@@ -149,7 +149,7 @@
     color: var(--txt-default);
     font-size: var(--txt-md);
     line-height: 1.25rem;
-    margin-bottom: 1.5rem;
+    margin-bottom: 1.25rem;
   }
 
   .wiki ul {

--- a/src/sass/components/wiki.scss
+++ b/src/sass/components/wiki.scss
@@ -91,78 +91,128 @@
   }
 
   .wiki h1 {
-    @apply text-text-default text-4xl font-bold mb-4
+    color: var(--txt-default);
+    font-size: 2.25rem /* 36px */;
+    line-height: 2.5rem;
+    font-weight: bold;
+    margin-bottom: 1rem;
   }
 
   .wiki h1 ~ h1 {
-    @apply mt-10
+    margin-top: 2.5rem;
   }
 
   .wiki h2 {
-    @apply border-b border-border-default text-text-default text-2xl font-bold mt-9 mb-4 pb-2
+    border-bottom: 1px solid var(--border-default);
+    color: var(--txt-default);
+    font-size: var(--txt-2xl);
+    line-height: 2rem;
+    font-weight: bold;
+    margin-top: 2.25rem;
+    margin-bottom: 1rem;
+    padding-bottom: 0.5rem;
   }
 
   .wiki h3 {
-    @apply text-text-default text-lg font-bold mt-4 mb-2
+    color: var(--txt-default);
+    font-size: var(--txt-lg);
+    line-height: 1.75rem;
+    font-weight: bold;
+    margin-top: 1rem;
+    margin-bottom: 0.5rem;
   }
 
   .wiki h4 {
-    @apply text-text-default text-base font-bold mb-2
+    color: var(--txt-default);
+    font-size: var(--txt-base);
+    line-height: 1.5rem;
+    font-weight: bold;
+    margin-bottom: 0.5rem;
   }
 
   .wiki h5 {
-    @apply text-sm font-bold mb-2
+    font-size: var(--txt-md);
+    line-height: 1.25rem;
+    font-weight: bold;
+    margin-bottom: 0.5rem;
   }
 
   .wiki h6 {
-    @apply text-text-caption text-sm font-bold mb-2
+    color: var(--txt-caption);
+    font-size: var(--txt-md);
+    line-height: 1.25rem;
+    font-weight: bold;
+    margin-bottom: 0.5rem;
   }
 
   .wiki p {
-    @apply text-text-default text-sm mb-6
+    color: var(--txt-default);
+    font-size: var(--txt-md);
+    line-height: 1.25rem;
+    margin-bottom: 1.5rem;
   }
 
   .wiki ul {
-    @apply list-disc ml-6 mb-6
+    list-style-type: disc;
+    margin-left: 1.5rem;
+    margin-bottom: 1.5rem;
   }
 
   .wiki ul li:not(:first-child) {
-    @apply mt-2
+    margin-top: 0.5rem;
   }
 
   .wiki ol {
-    @apply list-decimal ml-6 mb-6
+    list-style-type: decimal;
+    margin-left: 1.5rem;
+    margin-bottom: 1.5rem;
   }
 
   .wiki ol li:not(:first-child) {
-    @apply mt-2
+    margin-top: 0.5rem;
   }
 
   .wiki li > ul, .wiki li > ol {
-    @apply mt-2 mb-0
+    margin-top: 0.5rem;
+    margin-bottom: 0px;
   }
 
   .wiki li ul,
   .wiki li ol {
-    @apply ml-4
+    margin-left: 1rem;
   }
 
   .wiki table {
-    @apply border border-border-divider mb-4 p-2
+    border: 1px solid var(--border-divider);
+    margin-bottom: 1rem;
+    padding: 0.5rem;
   }
 
   .wiki th {
-    @apply bg-background-secondary border border-border-divider text-text-default text-xs font-bold p-2
+    background-color: var(--bg-secondary);
+    border: 1px solid var(--border-divider);
+    color: var(--txt-default);
+    font-size: var(--txt-xs);
+    line-height: 1rem;
+    font-weight: bold;
+    padding: 0.5rem;
   }
 
   .wiki td {
-    @apply border border-border-divider text-text-default text-sm p-2
+    border: 1px solid var(--border-divider);
+    color: var(--txt-default);
+    font-size: --txt-md;
+    line-height: 1.25rem;
+    padding: 0.5rem;
   }
 
 
   .wiki hr,
   .controller-issues div.issue .wiki hr {
-    @apply block h-[1px] my-4
+    display: block;
+    height: 1px;
+    margin-top: 1rem;
+    margin-bottom: 1rem;
   }
 
 
@@ -212,20 +262,31 @@
   }
 
   div.wiki *:not(pre)>code, div.wiki>code {
-    @apply bg-background-secondary border border-border-default text-text-danger mx-0.5 py-0.5 px-1.5 rounded
+    background-color: var(--bg-secondary);
+    border: 1px solid var(--border-default);
+    color: var(--txt-danger);
+    margin-left: 0.125rem;
+    margin-right: 0.125rem;
+    padding-top: 0.125rem;
+    padding-bottom: 0.125rem;
+    padding-left: 0.375rem;
+    padding-right: 0.375rem;
+    border-radius: var(--bd-radius-base);
   }
 
   .wiki blockquote pre {
-    @apply ml-1.5
+    margin-left: 0.375rem;
   }
 
 
   .wiki .task-list {
-    @apply ml-0 mb-4
+    margin-left: 0;
+    margin-bottom: 1rem;
   }
 
   .wiki .task-list .task-list {
-    @apply mt-2 ml-4
+    margin-top: 0.5rem;
+    margin-left: 1rem;
   }
 
   .wiki .task-list-item .task-list-item-checkbox + p {
@@ -234,69 +295,100 @@
 
 
   .wiki ul.toc {
-    @apply float-right max-w-[240px] min-w-[160px] bg-background-secondary border-none ml-4 p-4 rounded-md
+    float: right;
+    max-width: 240px;
+    min-width: 160px;
+    background-color: var(--bg-secondary);
+    border-style: none;
+    margin-left: 1rem;
+    padding: 1rem;
+    border-radius: var(--bd-radius-md);
   }
 
   .wiki ul.toc.right {
-    @apply ml-4
+    margin-left: 1rem /* 16px */;
   }
 
   .wiki ul.toc li {
-    @apply text-sm
+    font-size: var(--txt-md);
+    line-height: 1.25rem;
   }
 
   .wiki ul.toc > li:first-child {
-    @apply text-text-caption mb-2
+    color: var(--txt-caption);
+    margin-bottom: 0.5rem;
   }
 
   .wiki ul.toc li li {
-    @apply text-xs mt-2 ml-4
+    font-size: var(--txt-xs);
+    line-height: 1rem;
+    margin-top: 0.5rem;
+    margin-left: 1rem;
   }
 
   .wiki ul.toc a {
-    @apply text-xs
+    font-size: var(--txt-xs);
+    line-height: 1rem;
   }
 
   .wiki img {
-    @apply border-2 border-border-divider my-2
+    border: 2px solid var(--border-divider);
+    margin-top: 0.5rem;
+    margin-bottom: 0.5rem;
   }
 
 
   // diff
   .text-diff {
-    @apply bg-background-secondary border-none text-xs mt-2 rounded-md
+    background-color: var(--bg-secondary);
+    border-style: none;
+    font-size: var(--txt-xs);
+    line-height: 1rem;
+    margin-top: 0.5rem;
+    border-radius: var(--bd-radius-md);
   }
 
   #wiki_form textarea {
-    @apply mt-0
+    margin-top: 0px;
   }
 
   #wiki_form p, #wiki_form fieldset {
-    @apply mt-6
+    margin-top: 1.5rem;
   }
 
   #wiki_form fieldset {
-    @apply bg-background-primary border-border-divider p-4 rounded-md
+    background-color: var(--bg-primary);
+    border-color: var(--border-divider);
+    padding: 1rem;
+    border-radius: var(--bd-radius-md);
   }
 
   #wiki_form fieldset legend {
-    @apply font-bold
+    font-weight: bold;
   }
 
   #wiki_form #existing-attachments {
-    @apply border-b border-border-divider mb-4 pb-4
+    border-bottom: 1px solid var(--border-divider);
+    margin-bottom: 1rem;
+    padding-bottom: 1rem;
   }
 
   #wiki_form .new-attachments {
-    @apply w-full
+    width: 100%;
   }
 
   #wiki_form .box + p {
-    @apply flex items-center
+    display: flex;
+    align-items: center;
   }
 
   .wiki-page-version .buttons a:not([class]) {
-    @apply whitespace-normal w-auto h-auto bg-transparent border-none indent-0
+    white-space: normal;
+    width: auto;
+    height: auto;
+    background-color: transparent;
+    border-style: none;
+    text-indent: 0;
   }
 
 

--- a/src/sass/components/wiki.scss
+++ b/src/sass/components/wiki.scss
@@ -147,12 +147,6 @@
     @apply ml-4
   }
 
-  .wiki p + ul,
-  .wiki p + ol {
-    @apply -mt-2
-  }
-
-
   .wiki table {
     @apply border border-border-divider mb-4 p-2
   }


### PR DESCRIPTION
Textileへの対応。
Textileでは文章の直後に空行を入れないとpタグとして認識されないという仕様？がある。

それにより
```
<p>文章</p>

空行がないことで生成されたp無し文章
<ul>...
```
という構造が生まれた場合に、 `p + ul or ol`に適用していたネガティブマージンにより、p無し文章に被ってしまう現象が発生していた。