### PR TITLE
feat: redmine-7.0.0においても/projects/{Project#identifier}/settings/membersの画面でLychee-theme basicが提供するアイコンを使うように対応

### DIFF
--- a/src/sass/components/icons.scss
+++ b/src/sass/components/icons.scss
@@ -456,6 +456,7 @@ svg.icon-svg use[href$="#icon--checked"] {
   background-image: url(images/settings_dark.svg);
 }
 
+#list_organizations .icon-group:not(:has(svg)), /* https://github.com/redmine/redmine/blob/7.0.0/app/assets/stylesheets/legacy-icons-compat.css#L96 より高い優先度にするため */
 .icon-group,
 .icon-group:not(:has(svg)) {
   background-image: url(images/groups_3_default.svg);


### PR DESCRIPTION
https://github.com/agileware-jp/lychee_groups/pull/53 適用後に確認

### pull-request前: Redmineの画像

<img width="525" height="591" alt="image" src="https://github.com/user-attachments/assets/7a7e294c-8763-416c-b0dd-db163b5475c2" />

### pull-request後: Lychee-theme basicの画像

<img width="535" height="537" alt="image" src="https://github.com/user-attachments/assets/b786b92b-3f5d-4ac4-8f60-882a87b99a01" />
